### PR TITLE
Guard native agent writes and simplify release archives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1157,8 +1157,7 @@ jobs:
       - name: Check store-size figures carry a version and a method
         run: python3 scripts/check-store-size-figures.py
 
-      # ADDED here rather than moved out of `check`, for the reason the kin-vfs
-      # step below records. `check` carries `github.event_name != 'pull_request'`,
+      # `check` carries `github.event_name != 'pull_request'`,
       # so for as long as these two guards ran only there, a pull request could
       # introduce a raw filesystem read on an answer path and no check on that
       # pull request could report it; the guards graded the invariant only after
@@ -1176,21 +1175,6 @@ jobs:
 
       - name: Check Zero File-Search Invariant (answer modules)
         run: bash scripts/zero_file_search_guard.sh
-
-      # ADDED here rather than moved out of `check`, deliberately, for two
-      # reasons. `check` carries `github.event_name != 'pull_request'`, so the
-      # thinned six-context pull-request gate never runs it and main failed its
-      # own kin-vfs compatibility guard with no pull-request check ever showing
-      # it (FIR-2887); this job runs on a pull request, so the answer now
-      # arrives while a commit can still change it. And `bin/kin-precheck`
-      # enumerates the gate list out of `check` by name and refuses with no
-      # tally when a script it expects is missing there, so moving the step
-      # would have dropped it from every lane's local gate at the same time. The
-      # cost of running it in both places is one API read on a push.
-      - name: Verify Kin/kin-vfs compatibility at the pinned release input
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: node scripts/check-kin-vfs-compat.mjs
 
       # AGENTS.md's Landing section enumerates the required contexts on `main` as prose, read
       # from `GET /repos/firelock-ai/kin/rules/branches/main`. On 2026-09-03 that prose had
@@ -1388,7 +1372,6 @@ jobs:
             scripts/release-proof/merge-preflight-records.test.mjs \
             scripts/release-proof/vendored.test.mjs \
             scripts/check-glibc-floor.test.mjs \
-            scripts/check-kin-vfs-compat.test.mjs \
             scripts/wave-kin-vfs-core-hold.test.mjs \
             scripts/check-rc-build-drift.test.mjs \
             scripts/check-release-proof-artifacts.test.mjs \
@@ -2149,11 +2132,7 @@ jobs:
       # Every validator below polices a repo-global invariant, so a break in one
       # is a property of the tree rather than of the change under test and the
       # identical failure lands on every open pull request and every queue entry
-      # at once. On 2026-08-19 a kin-vfs pin that had drifted between
-      # release.yml and rc-build.yml failed this step 70 times and ejected 32
-      # queue entries; four of the seven pull requests it ejected touched
-      # nothing release-related and could neither have caused the drift nor
-      # fixed it. The gate runs the same validators and routes their failure:
+      # at once. The gate runs the same validators and routes their failure:
       # hard for anything reaching release machinery, for the release pull
       # request, for a push, and for a diff it cannot read, and a warning
       # annotation otherwise. The invocations stay here rather than moving into
@@ -2178,7 +2157,6 @@ jobs:
             scripts/release-proof/merge-preflight-records.test.mjs \
             scripts/release-proof/vendored.test.mjs \
             scripts/check-glibc-floor.test.mjs \
-            scripts/check-kin-vfs-compat.test.mjs \
             scripts/wave-kin-vfs-core-hold.test.mjs \
             scripts/check-rc-build-drift.test.mjs \
             scripts/check-release-proof-artifacts.test.mjs \
@@ -2204,30 +2182,8 @@ jobs:
       - name: Check the RC build mirrors the release build
         if: runner.os == 'Linux' && matrix.shard == 1
         run: node scripts/check-rc-build-drift.mjs
-
-      # release.yml refuses a release whose Kin lock resolves a different
-      # kin-vfs-core than the pinned kin-vfs checkout builds, and that
-      # comparison ran nowhere else: a pull request moving the Kin lock passed
-      # every required context and failed only after the tag existed, where the
-      # tag has already resolved its own workflows. Run the same comparison
-      # here, against the pin read out of release.yml, so the answer arrives
-      # while a commit can still change it.
-      - name: Verify Kin/kin-vfs compatibility at the pinned release input
-        if: runner.os == 'Linux' && matrix.shard == 1
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: node scripts/check-kin-vfs-compat.mjs
-
-      # ADDED here as well as in `fast-gate-lint`, for the reason the step above
-      # is duplicated too: `bin/kin-precheck` enumerates guard scripts out of
-      # THIS job by name (`JOB="check"`), so a guard that exists only in
-      # `fast-gate-lint` is invisible to it, not UNCLASSIFIED, just never
-      # enumerated at all, which was verified empirically before adding this
-      # copy. `check` carries `github.event_name != 'pull_request'`, so this
-      # instance buys no pull-request coverage on its own; `fast-gate-lint`'s
-      # copy already does that. This one buys every lane's local
-      # `bin/kin-precheck kin` and a second look on every push to main. The
-      # cost of running it in both places is one API read on a push.
+      # This check is duplicated with fast-gate-lint so both the pull-request
+      # and push paths verify the same branch-protection documentation.
       - name: Falsify required-contexts doc check
         if: runner.os == 'Linux' && matrix.shard == 1
         run: python3 scripts/check-required-contexts.py --self-test
@@ -3232,10 +3188,8 @@ jobs:
 
       # Assembled exactly as the release assembles it, down to the archive name,
       # the single top-level directory, and the shasum-format sidecar, so the
-      # installer takes its ordinary path over these bytes. kin-vfs and its shim
-      # are absent on purpose: they are built from a separate repository at a
-      # commit the release pins, and a pull request produces no such bytes.
-      # The shape helper the release publishes with is what judges the result.
+      # installer takes its ordinary path over these bytes. The shared shape
+      # helper judges the same supported runtime inventory the release ships.
       - name: Package the release archive layout
         run: |
           set -euo pipefail
@@ -3296,7 +3250,6 @@ jobs:
     uses: ./.github/workflows/install-proof.yml
     with:
       release_tag: ""
-      expected_vfs_commit: ""
       local_artifact: install-proof-pr-binaries
     permissions:
       contents: read

--- a/.github/workflows/install-proof.yml
+++ b/.github/workflows/install-proof.yml
@@ -15,10 +15,6 @@ on:
         description: Exact public release tag to install and verify.
         required: true
         type: string
-      expected_vfs_commit:
-        description: Reviewed kin-vfs commit pinned by the calling release workflow.
-        required: true
-        type: string
       local_artifact:
         description: >
           Name of an artifact in the CALLING run holding binaries this pull
@@ -163,7 +159,6 @@ jobs:
         shell: bash
         env:
           RELEASE_EVENT_TAG: ${{ inputs.release_tag || github.event.release.tag_name || '' }}
-          REVIEWED_VFS_COMMIT: ${{ inputs.expected_vfs_commit || '' }}
           LOCAL_ARTIFACT: ${{ inputs.local_artifact || '' }}
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -221,6 +216,7 @@ jobs:
               echo "installed kin-daemon $installed_daemon_version, expected pull request build $expected_version" >&2
               exit 1
             fi
+            printf 'false\n' > legacy-vfs-mode.txt
             exit 0
           fi
 
@@ -327,19 +323,8 @@ jobs:
             "https://github.com/firelock-ai/kin/releases/download/$expected_tag/release-provenance.json.sha256" \
             -o release-provenance.json.sha256
 
-          expected_vfs_commit="$REVIEWED_VFS_COMMIT"
-          if [ -z "$expected_vfs_commit" ]; then
-            expected_vfs_commit="$(node -e \
-              'process.stdout.write(JSON.parse(require("fs").readFileSync("release-provenance.json", "utf8")).kin_vfs?.commit || "")')"
-          fi
-          if ! printf '%s\n' "$expected_vfs_commit" | grep -Eq '^[0-9a-f]{40}$'; then
-            echo "could not resolve the reviewed kin-vfs commit for $expected_tag" >&2
-            exit 1
-          fi
-
           RELEASE_ASSET="$release_asset" EXPECTED_TAG="$expected_tag" \
-          EXPECTED_COMMIT="$expected_commit" \
-          EXPECTED_VFS_COMMIT="$expected_vfs_commit" node <<'NODE'
+          EXPECTED_COMMIT="$expected_commit" RUNNER_OS="$RUNNER_OS" node <<'NODE'
           const crypto = require("crypto");
           const fs = require("fs");
 
@@ -360,22 +345,51 @@ jobs:
             "release provenance tag does not match the installed release");
           fail(manifest.kin?.commit === process.env.EXPECTED_COMMIT,
             "release provenance Kin commit does not match the installed release tag");
-          fail(manifest.kin_vfs?.commit === process.env.EXPECTED_VFS_COMMIT,
-            "release provenance does not bind the reviewed kin-vfs commit");
-          fail(manifest.kin_vfs?.dirty === false,
-            "release provenance does not certify a clean kin-vfs checkout");
           const platform = manifest.artifacts?.find(
             (artifact) => artifact.archive?.name === process.env.RELEASE_ASSET
           );
           fail(platform, `release provenance omits ${process.env.RELEASE_ASSET}`);
+          fail(Array.isArray(platform.archive_contents),
+            "release provenance omits the archive content inventory");
           fail(platform.release_tag === process.env.EXPECTED_TAG,
             "platform provenance tag does not match the installed release");
           fail(platform.kin?.commit === process.env.EXPECTED_COMMIT,
             "platform provenance Kin commit does not match the installed release");
-          fail(platform.kin_vfs?.commit === process.env.EXPECTED_VFS_COMMIT,
-            "platform provenance does not bind the reviewed kin-vfs commit");
           fail(platform.archive?.sha256 === sha256(`attested-${process.env.RELEASE_ASSET}`),
             "attested archive bytes do not match aggregate release provenance");
+          const shim = process.env.RUNNER_OS === "Linux"
+            ? "libkin_vfs_shim.so"
+            : process.env.RUNNER_OS === "macOS"
+              ? "libkin_vfs_shim.dylib"
+              : null;
+          const names = new Set((platform.archive_contents ?? []).map((entry) => entry.name));
+          const hasVfs = names.has("kin-vfs");
+          const hasShim = shim !== null && names.has(shim);
+          fail(hasVfs === hasShim,
+            "archive carries a partial retired VFS runtime pair");
+          const legacyVfs = hasVfs && hasShim;
+          // v0.7.16 recorded the retired source input in its aggregate and every
+          // platform record, but Windows deliberately shipped no VFS pair. Keep
+          // that released provenance verifiable without allowing a future Unix
+          // archive to omit its pair or a future archive to retain either field.
+          const legacyVfsSource = manifest.kin_vfs !== undefined || platform.kin_vfs !== undefined;
+          if (legacyVfs || legacyVfsSource) {
+            const expectedVfsCommit = manifest.kin_vfs?.commit;
+            fail(/^[0-9a-f]{40}$/.test(expectedVfsCommit ?? ""),
+              "legacy release provenance does not bind a reviewed kin-vfs commit");
+            fail(manifest.kin_vfs?.dirty === false,
+              "legacy release provenance does not certify a clean kin-vfs checkout");
+            fail(platform.kin_vfs?.commit === expectedVfsCommit,
+              "legacy platform provenance does not bind the reviewed kin-vfs commit");
+            fail(legacyVfs || process.env.RUNNER_OS === "Windows",
+              "legacy VFS provenance may omit the runtime pair only on Windows");
+          } else {
+            fail(!names.has("kin-vfs"), "new archive unexpectedly carries kin-vfs");
+            fail(shim === null || !names.has(shim), "new archive unexpectedly carries a VFS preload shim");
+            fail(manifest.kin_vfs === undefined && platform.kin_vfs === undefined,
+              "new release provenance unexpectedly records retired VFS source inputs");
+          }
+          fs.writeFileSync("legacy-vfs-mode.txt", `${legacyVfs}\n`);
           NODE
 
           aggregate_verified=false
@@ -417,13 +431,13 @@ jobs:
           fi
 
           RUN_COMPONENT_COMPARE="$([ "$RUNNER_OS" != "Windows" ] && printf true || printf false)" \
+          LEGACY_VFS="$(cat legacy-vfs-mode.txt)" \
           RELEASE_ASSET="$release_asset" EXPECTED_TAG="$expected_tag" \
           EXPECTED_COMMIT="$expected_commit" CONTENT_ROOT="$content_root" \
-          EXPECTED_VFS_COMMIT="$expected_vfs_commit" \
           INSTALLED_VFS="$HOME/.kin/bin/kin-vfs" \
           INSTALLED_SHIM="$HOME/.kin/lib/$shim_name" \
           SHIM_NAME="$shim_name" node <<'NODE'
-          if (process.env.RUN_COMPONENT_COMPARE !== "true") process.exit(0);
+          if (process.env.RUN_COMPONENT_COMPARE !== "true" || process.env.LEGACY_VFS !== "true") process.exit(0);
           const crypto = require("crypto");
           const fs = require("fs");
           const path = require("path");
@@ -459,7 +473,7 @@ jobs:
             schema_version: 1,
             release_tag: process.env.EXPECTED_TAG,
             kin_commit: process.env.EXPECTED_COMMIT,
-            kin_vfs_commit: process.env.EXPECTED_VFS_COMMIT,
+            kin_vfs_commit: platform.kin_vfs?.commit,
             archive: process.env.RELEASE_ASSET,
             components,
           }, null, 2)}\n`);
@@ -1309,17 +1323,20 @@ jobs:
           child.stdin.write(`${requests.map((request) => JSON.stringify(request)).join("\n")}\n`);
           NODE
 
-      # kin-vfs and its shim are built from a separate repository at a commit
-      # the release workflow pins, so a pull request produces no such bytes and
-      # its archive carries none. The installer says so out loud and the CLI
-      # reports the projection unsupported, which the capability validator below
-      # requires in that mode rather than tolerating any status.
+      # Published archives before this retirement carried the separate VFS
+      # runtime. Preserve its proof only when the attested archive inventory
+      # records the complete legacy pair. New archives deliberately skip it and
+      # the capability validator requires VFS projection to be unsupported.
       - name: Graph-backed VFS projection proof
         if: runner.os != 'Windows' && !inputs.local_artifact
         shell: bash
         working-directory: kin-install-proof
         run: |
           set -euo pipefail
+          if [ "$(cat ../legacy-vfs-mode.txt)" != true ]; then
+            echo "retired VFS runtime absent from this archive; projection proof is unsupported by contract"
+            exit 0
+          fi
           # Same capture directory the first-run step opened. The VFS logs and
           # the probe's own output are reports about the tree, so they stay out
           # of it while the daemon is watching.
@@ -1724,10 +1741,10 @@ jobs:
           const path = require("path");
           const runnerOs = process.env.RUNNER_OS;
           const isWindows = runnerOs === "Windows";
-          const isPullRequestBuild = (process.env.LOCAL_ARTIFACT ?? "") !== "";
           const expectedCommit = fs.readFileSync("../expected-commit.txt", "utf8").trim();
           const expectedLock = fs.readFileSync("../expected-lock-sha.txt", "utf8").trim();
           const installedKin = fs.readFileSync("../installed-kin-command.txt", "utf8").trim();
+          const legacyVfs = fs.readFileSync("../legacy-vfs-mode.txt", "utf8").trim() === "true";
           const expectedInstalledKin = path.join(os.homedir(), ".kin", "bin", isWindows ? "kin.exe" : "kin");
           if (installedKin !== expectedInstalledKin) {
             throw new Error(`installed Kin command proof ${installedKin || "missing"} does not equal ${expectedInstalledKin}`);
@@ -1900,7 +1917,7 @@ jobs:
             ["shell_path", "healthy"],
             ["setup_ledger", "healthy"],
             ["registry_authority", isWindows ? "unsupported" : "healthy"],
-            ["vfs_projection", isWindows || isPullRequestBuild ? "unsupported" : "healthy"],
+            ["vfs_projection", isWindows || !legacyVfs ? "unsupported" : "healthy"],
             ["mcp_client_claude", "healthy"],
             ["mcp_client_cursor", "healthy"],
             ["mcp_client_codex", "healthy"],

--- a/.github/workflows/rc-build.yml
+++ b/.github/workflows/rc-build.yml
@@ -87,30 +87,17 @@ jobs:
           # the header. Keeping the row shape identical is what lets a missing
           # row be added here by copying one line.
           #
-          # DELTA(skip_vfs): every row declares it. Three shared steps read
-          # matrix.skip_vfs, and release.yml gets the key from the windows row
-          # this matrix does not carry, so without it actionlint rejects those
-          # steps against a matrix type that has no such property. The value is
-          # the same false those steps already saw on every non-windows row.
           - os: ubuntu-latest
             target: x86_64-unknown-linux-musl
-            vfs_target: x86_64-unknown-linux-gnu
             artifact: kin-linux-x86_64
-            skip_vfs: false
-            shim_name: libkin_vfs_shim.so
             cross: false
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-musl
-            vfs_target: aarch64-unknown-linux-gnu
             artifact: kin-linux-aarch64
-            skip_vfs: false
-            shim_name: libkin_vfs_shim.so
             cross: false
           - os: macos-latest
             target: aarch64-apple-darwin
             artifact: kin-macos-aarch64
-            skip_vfs: false
-            shim_name: libkin_vfs_shim.dylib
             cross: false
 
     steps:
@@ -162,9 +149,7 @@ jobs:
       - name: Install Rust stable
         uses: ./.github/actions/rust-toolchain
         with:
-          # On the Linux legs the core (kin, kin-daemon) targets musl and the VFS
-          # leg targets gnu (vfs_target), so both targets must be installed.
-          targets: ${{ matrix.target }}${{ matrix.vfs_target && format(' {0}', matrix.vfs_target) || '' }}
+          targets: ${{ matrix.target }}
 
       # musl-static C dependencies (ring, oniguruma, sqlite, tree-sitter) need a
       # musl-targeting C compiler; musl-tools provides musl-gcc. Only the Linux
@@ -185,15 +170,6 @@ jobs:
         if: matrix.cross
         run: cargo install cross --git https://github.com/cross-rs/cross
 
-      - name: Checkout kin-vfs
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          repository: firelock-ai/kin-vfs
-          path: kin-vfs
-          # Release inputs must never move under an unchanged Kin tag.
-          ref: 199818f0d1d9ff934de76b73b353183352db08b3
-          persist-credentials: false
-
       - name: Verify canonical release input bytes
         shell: bash
         run: |
@@ -202,63 +178,21 @@ jobs:
           const childProcess = require("child_process");
           const crypto = require("crypto");
           const fs = require("fs");
-          const path = require("path");
 
           const sha256 = (bytes) =>
             crypto.createHash("sha256").update(bytes).digest("hex");
-          for (const [label, root] of [["Kin", process.cwd()], ["kin-vfs", path.join(process.cwd(), "kin-vfs")]]) {
-            const tracked = childProcess.execFileSync(
-              "git",
-              ["cat-file", "blob", "HEAD:Cargo.lock"],
-              { cwd: root }
-            );
-            const working = fs.readFileSync(path.join(root, "Cargo.lock"));
-            if (!working.equals(tracked)) {
-              throw new Error(
-                `${label} Cargo.lock working bytes ${sha256(working)} do not match ` +
-                `tracked Git bytes ${sha256(tracked)}; refusing platform-specific release provenance`
-              );
-            }
-            console.log(`Verified canonical ${label} Cargo.lock bytes: ${sha256(tracked)}`);
-          }
-
-          const lockPackages = (lockPath) => fs.readFileSync(lockPath, "utf8")
-            .split("[[package]]")
-            .slice(1)
-            .map((block) => ({
-              name: block.match(/^name = "([^"]+)"/m)?.[1],
-              version: block.match(/^version = "([^"]+)"/m)?.[1],
-              source: block.match(/^source = "([^"]+)"/m)?.[1] ?? null,
-            }));
-          // Kin's side is the kin-vfs-core Kin BUILDS WITH, wherever it comes from. It
-          // used to come only from the registry; since the crate moved into
-          // crates/kin-vfs-core it has no `source` line at all, the shape a workspace
-          // member has in any lock. Both are accepted, and the question is unchanged:
-          // the shipped kin-vfs binaries are built from the pinned kin-vfs checkout, and
-          // if that checkout builds a different kin-vfs-core than Kin does, the release
-          // is wrong. The pinned side keeps the strict `source === null` rule, because
-          // that lock is the kin-vfs repository's own and its member entry is the one
-          // being compared. scripts/check-kin-vfs-compat.mjs is the pull-request
-          // counterpart and carries the same rule with its own tests.
-          const kinVfsCore = lockPackages(path.join(process.cwd(), "Cargo.lock"))
-            .filter((pkg) => pkg.name === "kin-vfs-core"
-              && (pkg.source === null || pkg.source.startsWith("sparse+")));
-          const pinnedVfsCore = lockPackages(path.join(process.cwd(), "kin-vfs", "Cargo.lock"))
-            .filter((pkg) => pkg.name === "kin-vfs-core" && pkg.source === null);
-          if (kinVfsCore.length !== 1 || pinnedVfsCore.length !== 1) {
+          const tracked = childProcess.execFileSync(
+            "git",
+            ["cat-file", "blob", "HEAD:Cargo.lock"],
+          );
+          const working = fs.readFileSync("Cargo.lock");
+          if (!working.equals(tracked)) {
             throw new Error(
-              `expected one Kin kin-vfs-core, from the registry or from this workspace, ` +
-              `and one pinned local kin-vfs-core; ` +
-              `found ${kinVfsCore.length} and ${pinnedVfsCore.length}`
+              `Kin Cargo.lock working bytes ${sha256(working)} do not match ` +
+              `tracked Git bytes ${sha256(tracked)}; refusing release provenance`
             );
           }
-          if (kinVfsCore[0].version !== pinnedVfsCore[0].version) {
-            throw new Error(
-              `Kin resolves kin-vfs-core ${kinVfsCore[0].version}, but the pinned release ` +
-              `checkout builds ${pinnedVfsCore[0].version}; update the immutable kin-vfs pin`
-            );
-          }
-          console.log(`Verified Kin/kin-vfs release compatibility at kin-vfs-core ${kinVfsCore[0].version}`);
+          console.log(`Verified canonical Kin Cargo.lock bytes: ${sha256(tracked)}`);
           NODE
 
       - name: Assert clean release source
@@ -269,12 +203,6 @@ jobs:
           if [ -n "$dirty" ]; then
             printf '%s\n' "$dirty" >&2
             echo "::error::release checkout is not clean before compilation"
-            exit 1
-          fi
-          vfs_dirty="$(git -C kin-vfs status --porcelain --untracked-files=all)"
-          if [ -n "$vfs_dirty" ]; then
-            printf '%s\n' "$vfs_dirty" >&2
-            echo "::error::pinned kin-vfs checkout is not clean before compilation"
             exit 1
           fi
 
@@ -422,103 +350,6 @@ jobs:
         env:
           TARGET: ${{ matrix.target }}
 
-      # kin and kin-daemon are static musl and carry no glibc floor at all. The
-      # VFS pair is the only glibc-linked thing Kin publishes for Linux, and
-      # until now its floor was a property of the runner image: Rust std
-      # references pidfd_spawnp and pidfd_getpid as weak undefined symbols, the
-      # linker binds them to whatever libc the build host exports, and the
-      # ubuntu-24.04 images export them at GLIBC_2.39. v0.5.38 shipped a
-      # linux-aarch64 kin-vfs the Debian 12 loader refused outright for exactly
-      # that reason. Zig ships glibc headers for every version, so building
-      # through it pins the floor to a number under review here rather than to
-      # whichever image the runner label resolves to this month.
-      - name: Install the pinned glibc floor toolchain (Linux)
-        if: ${{ runner.os == 'Linux' && !matrix.cross && !matrix.skip_vfs }}
-        shell: bash
-        env:
-          ZIG_VERSION: "0.13.0"
-          CARGO_ZIGBUILD_VERSION: "0.19.8"
-          # Published by ziglang.org/download/index.json for these exact
-          # tarballs. A release input must be immutable, so the download is
-          # checked rather than trusted.
-          ZIG_SHA256_X86_64: d45312e61ebcc48032b77bc4cf7fd6915c11fa16e4aad116b66c9468211230ea
-          ZIG_SHA256_AARCH64: 041ac42323837eb5624068acd8b00cd5777dac4cf91179e8dad7a7e90dd0c556
-        run: |
-          set -euo pipefail
-          case "$(uname -m)" in
-            x86_64) zig_arch=x86_64; zig_sha="$ZIG_SHA256_X86_64" ;;
-            aarch64) zig_arch=aarch64; zig_sha="$ZIG_SHA256_AARCH64" ;;
-            *)
-              echo "::error::no pinned zig tarball for Linux $(uname -m); the release cannot pin its glibc floor on this host"
-              exit 1
-              ;;
-          esac
-          tarball="$RUNNER_TEMP/zig-${ZIG_VERSION}.tar.xz"
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused \
-            --location --silent --show-error --fail \
-            "https://ziglang.org/download/${ZIG_VERSION}/zig-linux-${zig_arch}-${ZIG_VERSION}.tar.xz" \
-            --output "$tarball"
-          echo "${zig_sha}  ${tarball}" | sha256sum --check --strict -
-          mkdir -p "$RUNNER_TEMP/zig"
-          tar -xJf "$tarball" -C "$RUNNER_TEMP/zig" --strip-components=1
-          echo "$RUNNER_TEMP/zig" >> "$GITHUB_PATH"
-          cargo install cargo-zigbuild --locked --version "$CARGO_ZIGBUILD_VERSION"
-
-      - name: Build kin-vfs (native)
-        if: ${{ !matrix.cross && !matrix.skip_vfs }}
-        working-directory: kin-vfs
-        shell: bash
-        run: |
-          set -euo pipefail
-          # The VFS shim is an LD_PRELOAD libc interceptor and is therefore
-          # libc-specific: on Linux it builds against gnu (VFS_TARGET) so it can
-          # preload into the host distro's glibc programs. macOS/Windows have no
-          # vfs_target, so VFS_TARGET falls back to the core target there.
-          # The mount features are what make the shipped driver able to serve a
-          # projection the operating system mounts, rather than only the
-          # injected shim. macOS gets nfs because it carries an NFS client in
-          # the base system; Linux gets fuse below because it carries libfuse
-          # far more widely than a configured NFS client. Neither flag moves the
-          # glibc floor or adds a runtime dependency: building the same tree
-          # with and without them yields an identical shared-library set and an
-          # identical set of referenced GLIBC symbol versions, and fuser links
-          # no library because it mounts through the fusermount3 helper.
-          # --locked still holds: nfsserve and fuser are already in kin-vfs's
-          # tracked lock at the pinned ref.
-          if [ "$RUNNER_OS" != "Linux" ]; then
-            cargo build --locked --release --target "$VFS_TARGET" -p kin-vfs-cli --features nfs
-            cargo build --locked --release --target "$VFS_TARGET" -p kin-vfs-shim
-            exit 0
-          fi
-          # The floor is read out of the guard rather than written here as
-          # well. A build targeting one floor while the guard enforces another
-          # is worse than no guard, and the two drifting apart is exactly the
-          # shape that survives review.
-          floor="$(node "$GITHUB_WORKSPACE/scripts/check-glibc-floor.mjs" --print-floor)"
-          # zig cc does not search Debian/Ubuntu multiarch directories, and the
-          # OpenSSL that kin-vfs-daemon links through reqwest lives in them:
-          # the headers under /usr/include/<multiarch> and the link libraries
-          # under /usr/lib/<multiarch>. Both Linux legs build natively, so the
-          # multiarch triple is the VFS target's architecture.
-          multiarch="${VFS_TARGET%%-*}-linux-gnu"
-          scoped="$(printf '%s' "$VFS_TARGET" | tr - _)"
-          upper="$(printf '%s' "$scoped" | tr '[:lower:]' '[:upper:]')"
-          export "CFLAGS_${scoped}=-I/usr/include/${multiarch}"
-          export "CARGO_TARGET_${upper}_RUSTFLAGS=-L native=/usr/lib/${multiarch}"
-          cargo zigbuild --locked --release --target "${VFS_TARGET}.${floor}" -p kin-vfs-cli --features fuse
-          cargo zigbuild --locked --release --target "${VFS_TARGET}.${floor}" -p kin-vfs-shim
-        env:
-          VFS_TARGET: ${{ matrix.vfs_target || matrix.target }}
-
-      - name: Build kin-vfs (cross)
-        if: ${{ matrix.cross }}
-        working-directory: kin-vfs
-        run: |
-          cross build --locked --release --target "$TARGET" -p kin-vfs-cli
-          cross build --locked --release --target "$TARGET" -p kin-vfs-shim
-        env:
-          TARGET: ${{ matrix.target }}
-
       - name: Verify native release build provenance
         if: ${{ !matrix.cross }}
         shell: bash
@@ -612,12 +443,6 @@ jobs:
             echo "::error::release build mutated the source checkout"
             exit 1
           fi
-          vfs_dirty="$(git -C kin-vfs status --porcelain --untracked-files=all)"
-          if [ -n "$vfs_dirty" ]; then
-            printf '%s\n' "$vfs_dirty" >&2
-            echo "::error::release build mutated the pinned kin-vfs checkout"
-            exit 1
-          fi
 
       - name: Package (Unix)
         if: runner.os != 'Windows'
@@ -628,10 +453,6 @@ jobs:
           # archive lets `kin init` succeed but then `kin status`/`kin search`
           # fail with no daemon on PATH, so a missing daemon must fail the build.
           cp "target/${TARGET}/release/kin-daemon" "$ARTIFACT/"
-          # kin-vfs (cli + shim) is built under VFS_TARGET, which on Linux is the
-          # gnu triple (the shim is libc-specific) and elsewhere equals TARGET.
-          cp "kin-vfs/target/${VFS_TARGET}/release/kin-vfs" "$ARTIFACT/"
-          cp "kin-vfs/target/${VFS_TARGET}/release/${SHIM_NAME}" "$ARTIFACT/"
           # KinNotifier.app is macOS-only and is copied whole: -R preserves the
           # bundle structure and the stapled notarization ticket inside it.
           if [ -d "target/${TARGET}/release/KinNotifier.app" ]; then
@@ -639,8 +460,8 @@ jobs:
           fi
           # Words, not just executables. Both arms of the isolated stranger run
           # installed this archive successfully and both scored the packaging
-          # below the binaries, because nothing in it says where the three
-          # executables go or that the shared library belongs somewhere else.
+          # below the binaries, because nothing in it says where the two
+          # executables go or that the daemon belongs beside the CLI.
           node scripts/write-release-archive-docs.mjs "$ARTIFACT" "$TARGET" "$RC_VERSION"
           tar czf "${ARTIFACT}.tar.gz" "$ARTIFACT"
           # Take the listing once into a file. Piping it into `grep -q` lets grep
@@ -650,7 +471,7 @@ jobs:
           ARCHIVE_LISTING="$RUNNER_TEMP/${ARTIFACT}.listing.txt"
           tar tzf "${ARTIFACT}.tar.gz" > "$ARCHIVE_LISTING"
           # All supported Unix surfaces are mandatory release contents.
-          for required in kin kin-daemon kin-vfs "$SHIM_NAME" README.md INSTALL.md checksums-sha256.txt; do
+          for required in kin kin-daemon README.md INSTALL.md checksums-sha256.txt; do
             if ! grep -q "/${required}$" "$ARCHIVE_LISTING"; then
               echo "::error::$required missing from ${ARTIFACT}.tar.gz"
               exit 1
@@ -668,24 +489,7 @@ jobs:
           shasum -a 256 "${ARTIFACT}.tar.gz" > "${ARTIFACT}.tar.gz.sha256"
         env:
           TARGET: ${{ matrix.target }}
-          VFS_TARGET: ${{ matrix.vfs_target || matrix.target }}
           ARTIFACT: ${{ matrix.artifact }}
-          SHIM_NAME: ${{ matrix.shim_name }}
-
-      # Read the floor back off the bytes that were just packaged. The build
-      # above pins it, and a pin goes quiet the day it stops taking effect,
-      # which is how v0.5.38 published a kin-vfs that no Debian 12 could start
-      # while every check in this workflow stayed green. This step is the half
-      # that cannot pass by accident: it names the highest GLIBC requirement in
-      # each shipped dynamic binary and the symbols that set it, and refuses the
-      # release above the floor.
-      - name: Verify the packaged Linux binaries meet the published glibc floor
-        if: ${{ runner.os == 'Linux' && !matrix.skip_vfs }}
-        shell: bash
-        run: node scripts/check-glibc-floor.mjs "$ARTIFACT/kin-vfs" "$ARTIFACT/$SHIM_NAME"
-        env:
-          ARTIFACT: ${{ matrix.artifact }}
-          SHIM_NAME: ${{ matrix.shim_name }}
 
       - name: Package (Windows)
         if: runner.os == 'Windows'
@@ -696,8 +500,6 @@ jobs:
           # kin-daemon is mandatory: fail hard if it's missing rather
           # than ship a daemon-less archive that can `kin init` but nothing else.
           Copy-Item "target/$env:TARGET/release/kin-daemon.exe" "$env:ARTIFACT/" -ErrorAction Stop
-          Copy-Item "kin-vfs/target/$env:TARGET/release/kin-vfs.exe" "$env:ARTIFACT/" -ErrorAction SilentlyContinue
-          Copy-Item "kin-vfs/target/$env:TARGET/release/$env:SHIM_NAME" "$env:ARTIFACT/" -ErrorAction SilentlyContinue
           # See the Unix leg: the archive carries its own README, INSTALL and
           # checksum manifest so a stranger is not guessing at layout.
           node scripts/write-release-archive-docs.mjs "$env:ARTIFACT" "$env:TARGET" $env:RC_VERSION
@@ -775,15 +577,12 @@ jobs:
         env:
           TARGET: ${{ matrix.target }}
           ARTIFACT: ${{ matrix.artifact }}
-          SHIM_NAME: ${{ matrix.shim_name }}
 
       - name: Generate artifact provenance manifest
         shell: bash
         env:
           ARTIFACT: ${{ matrix.artifact }}
           TARGET: ${{ matrix.target }}
-          VFS_TARGET: ${{ matrix.vfs_target || matrix.target }}
-          EXPECTED_VFS_COMMIT: 199818f0d1d9ff934de76b73b353183352db08b3
         run: |
           set -euo pipefail
           node <<'NODE'
@@ -808,14 +607,7 @@ jobs:
             childProcess.execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
 
           const kinCommit = git(root, "rev-parse", "HEAD");
-          const vfsRoot = path.join(root, "kin-vfs");
-          const vfsCommit = git(vfsRoot, "rev-parse", "HEAD");
-          if (vfsCommit !== process.env.EXPECTED_VFS_COMMIT) {
-            throw new Error(`kin-vfs checkout ${vfsCommit} does not match pinned ${process.env.EXPECTED_VFS_COMMIT}`);
-          }
-
           const kinLockSha = sha256(path.join(root, "Cargo.lock"));
-          const vfsLockSha = sha256(path.join(vfsRoot, "Cargo.lock"));
           const buildMetaPath = path.join(
             process.env.RUNNER_TEMP,
             `kin-release-provenance-${target}`,
@@ -915,16 +707,10 @@ jobs:
             },
             artifact,
             target,
-            vfs_target: process.env.VFS_TARGET,
             kin: {
               commit: kinCommit,
               cargo_lock_sha256: kinLockSha,
               embedded_dependency_provenance: buildMeta.dependency_provenance,
-            },
-            kin_vfs: {
-              commit: vfsCommit,
-              dirty: false,
-              cargo_lock_sha256: vfsLockSha,
             },
             archive: archiveRecord(archive),
             ...(additionalArchiveNames.length

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -478,22 +478,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Linux core binaries (kin, kin-daemon) target musl and link static by
-          # default, so a single artifact runs on any Linux distro: musl (Alpine)
-          # and glibc (Ubuntu/Debian/RHEL) alike, with no OpenSSL or glibc version
-          # coupling. The VFS leg builds against gnu (vfs_target) because an
-          # LD_PRELOAD shim is intrinsically libc-specific (see the VFS steps).
+          # Linux runtime binaries (kin, kin-daemon) target musl and link static
+          # by default, so a single artifact runs on musl (Alpine) and glibc
+          # (Ubuntu/Debian/RHEL) systems without an OpenSSL or glibc dependency.
           - os: ubuntu-latest
             target: x86_64-unknown-linux-musl
-            vfs_target: x86_64-unknown-linux-gnu
             artifact: kin-linux-x86_64
-            shim_name: libkin_vfs_shim.so
             cross: false
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-musl
-            vfs_target: aarch64-unknown-linux-gnu
             artifact: kin-linux-aarch64
-            shim_name: libkin_vfs_shim.so
             cross: false
           # Use an Intel host so this archive is executed before packaging;
           # building x86_64 on an arm64 runner would leave it unproven.
@@ -521,23 +515,14 @@ jobs:
           - os: macos-15-intel
             target: x86_64-apple-darwin
             artifact: kin-macos-x86_64
-            shim_name: libkin_vfs_shim.dylib
             cross: false
           - os: macos-latest
             target: aarch64-apple-darwin
             artifact: kin-macos-aarch64
-            shim_name: libkin_vfs_shim.dylib
             cross: false
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             artifact: kin-windows-x86_64
-            shim_name: kin_vfs_shim.dll
-            # kin-vfs only. This row used to carry `skip_vector: true`, which
-            # gated BOTH the vector feature set and the kin-vfs build, so
-            # shipping vectors on Windows by deleting that one key would also
-            # have started building an LD_PRELOAD libc interceptor for msvc.
-            # The two are unrelated and are now named separately.
-            skip_vfs: true
             cross: false
 
     steps:
@@ -554,9 +539,7 @@ jobs:
       - name: Install Rust stable
         uses: ./.github/actions/rust-toolchain
         with:
-          # On the Linux legs the core (kin, kin-daemon) targets musl and the VFS
-          # leg targets gnu (vfs_target), so both targets must be installed.
-          targets: ${{ matrix.target }}${{ matrix.vfs_target && format(' {0}', matrix.vfs_target) || '' }}
+          targets: ${{ matrix.target }}
 
       # musl-static C dependencies (ring, oniguruma, sqlite, tree-sitter) need a
       # musl-targeting C compiler; musl-tools provides musl-gcc. Only the Linux
@@ -577,15 +560,6 @@ jobs:
         if: matrix.cross
         run: cargo install cross --git https://github.com/cross-rs/cross
 
-      - name: Checkout kin-vfs
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          repository: firelock-ai/kin-vfs
-          path: kin-vfs
-          # Release inputs must never move under an unchanged Kin tag.
-          ref: 199818f0d1d9ff934de76b73b353183352db08b3
-          persist-credentials: false
-
       - name: Verify canonical release input bytes
         shell: bash
         run: |
@@ -594,63 +568,21 @@ jobs:
           const childProcess = require("child_process");
           const crypto = require("crypto");
           const fs = require("fs");
-          const path = require("path");
 
           const sha256 = (bytes) =>
             crypto.createHash("sha256").update(bytes).digest("hex");
-          for (const [label, root] of [["Kin", process.cwd()], ["kin-vfs", path.join(process.cwd(), "kin-vfs")]]) {
-            const tracked = childProcess.execFileSync(
-              "git",
-              ["cat-file", "blob", "HEAD:Cargo.lock"],
-              { cwd: root }
-            );
-            const working = fs.readFileSync(path.join(root, "Cargo.lock"));
-            if (!working.equals(tracked)) {
-              throw new Error(
-                `${label} Cargo.lock working bytes ${sha256(working)} do not match ` +
-                `tracked Git bytes ${sha256(tracked)}; refusing platform-specific release provenance`
-              );
-            }
-            console.log(`Verified canonical ${label} Cargo.lock bytes: ${sha256(tracked)}`);
-          }
-
-          const lockPackages = (lockPath) => fs.readFileSync(lockPath, "utf8")
-            .split("[[package]]")
-            .slice(1)
-            .map((block) => ({
-              name: block.match(/^name = "([^"]+)"/m)?.[1],
-              version: block.match(/^version = "([^"]+)"/m)?.[1],
-              source: block.match(/^source = "([^"]+)"/m)?.[1] ?? null,
-            }));
-          // Kin's side is the kin-vfs-core Kin BUILDS WITH, wherever it comes from. It
-          // used to come only from the registry; since the crate moved into
-          // crates/kin-vfs-core it has no `source` line at all, the shape a workspace
-          // member has in any lock. Both are accepted, and the question is unchanged:
-          // the shipped kin-vfs binaries are built from the pinned kin-vfs checkout, and
-          // if that checkout builds a different kin-vfs-core than Kin does, the release
-          // is wrong. The pinned side keeps the strict `source === null` rule, because
-          // that lock is the kin-vfs repository's own and its member entry is the one
-          // being compared. scripts/check-kin-vfs-compat.mjs is the pull-request
-          // counterpart and carries the same rule with its own tests.
-          const kinVfsCore = lockPackages(path.join(process.cwd(), "Cargo.lock"))
-            .filter((pkg) => pkg.name === "kin-vfs-core"
-              && (pkg.source === null || pkg.source.startsWith("sparse+")));
-          const pinnedVfsCore = lockPackages(path.join(process.cwd(), "kin-vfs", "Cargo.lock"))
-            .filter((pkg) => pkg.name === "kin-vfs-core" && pkg.source === null);
-          if (kinVfsCore.length !== 1 || pinnedVfsCore.length !== 1) {
+          const tracked = childProcess.execFileSync(
+            "git",
+            ["cat-file", "blob", "HEAD:Cargo.lock"],
+          );
+          const working = fs.readFileSync("Cargo.lock");
+          if (!working.equals(tracked)) {
             throw new Error(
-              `expected one Kin kin-vfs-core, from the registry or from this workspace, ` +
-              `and one pinned local kin-vfs-core; ` +
-              `found ${kinVfsCore.length} and ${pinnedVfsCore.length}`
+              `Kin Cargo.lock working bytes ${sha256(working)} do not match ` +
+              `tracked Git bytes ${sha256(tracked)}; refusing release provenance`
             );
           }
-          if (kinVfsCore[0].version !== pinnedVfsCore[0].version) {
-            throw new Error(
-              `Kin resolves kin-vfs-core ${kinVfsCore[0].version}, but the pinned release ` +
-              `checkout builds ${pinnedVfsCore[0].version}; update the immutable kin-vfs pin`
-            );
-          }
-          console.log(`Verified Kin/kin-vfs release compatibility at kin-vfs-core ${kinVfsCore[0].version}`);
+          console.log(`Verified canonical Kin Cargo.lock bytes: ${sha256(tracked)}`);
           NODE
 
       - name: Assert clean release source
@@ -661,12 +593,6 @@ jobs:
           if [ -n "$dirty" ]; then
             printf '%s\n' "$dirty" >&2
             echo "::error::release checkout is not clean before compilation"
-            exit 1
-          fi
-          vfs_dirty="$(git -C kin-vfs status --porcelain --untracked-files=all)"
-          if [ -n "$vfs_dirty" ]; then
-            printf '%s\n' "$vfs_dirty" >&2
-            echo "::error::pinned kin-vfs checkout is not clean before compilation"
             exit 1
           fi
 
@@ -814,103 +740,6 @@ jobs:
         env:
           TARGET: ${{ matrix.target }}
 
-      # kin and kin-daemon are static musl and carry no glibc floor at all. The
-      # VFS pair is the only glibc-linked thing Kin publishes for Linux, and
-      # until now its floor was a property of the runner image: Rust std
-      # references pidfd_spawnp and pidfd_getpid as weak undefined symbols, the
-      # linker binds them to whatever libc the build host exports, and the
-      # ubuntu-24.04 images export them at GLIBC_2.39. v0.5.38 shipped a
-      # linux-aarch64 kin-vfs the Debian 12 loader refused outright for exactly
-      # that reason. Zig ships glibc headers for every version, so building
-      # through it pins the floor to a number under review here rather than to
-      # whichever image the runner label resolves to this month.
-      - name: Install the pinned glibc floor toolchain (Linux)
-        if: ${{ runner.os == 'Linux' && !matrix.cross && !matrix.skip_vfs }}
-        shell: bash
-        env:
-          ZIG_VERSION: "0.13.0"
-          CARGO_ZIGBUILD_VERSION: "0.19.8"
-          # Published by ziglang.org/download/index.json for these exact
-          # tarballs. A release input must be immutable, so the download is
-          # checked rather than trusted.
-          ZIG_SHA256_X86_64: d45312e61ebcc48032b77bc4cf7fd6915c11fa16e4aad116b66c9468211230ea
-          ZIG_SHA256_AARCH64: 041ac42323837eb5624068acd8b00cd5777dac4cf91179e8dad7a7e90dd0c556
-        run: |
-          set -euo pipefail
-          case "$(uname -m)" in
-            x86_64) zig_arch=x86_64; zig_sha="$ZIG_SHA256_X86_64" ;;
-            aarch64) zig_arch=aarch64; zig_sha="$ZIG_SHA256_AARCH64" ;;
-            *)
-              echo "::error::no pinned zig tarball for Linux $(uname -m); the release cannot pin its glibc floor on this host"
-              exit 1
-              ;;
-          esac
-          tarball="$RUNNER_TEMP/zig-${ZIG_VERSION}.tar.xz"
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused \
-            --location --silent --show-error --fail \
-            "https://ziglang.org/download/${ZIG_VERSION}/zig-linux-${zig_arch}-${ZIG_VERSION}.tar.xz" \
-            --output "$tarball"
-          echo "${zig_sha}  ${tarball}" | sha256sum --check --strict -
-          mkdir -p "$RUNNER_TEMP/zig"
-          tar -xJf "$tarball" -C "$RUNNER_TEMP/zig" --strip-components=1
-          echo "$RUNNER_TEMP/zig" >> "$GITHUB_PATH"
-          cargo install cargo-zigbuild --locked --version "$CARGO_ZIGBUILD_VERSION"
-
-      - name: Build kin-vfs (native)
-        if: ${{ !matrix.cross && !matrix.skip_vfs }}
-        working-directory: kin-vfs
-        shell: bash
-        run: |
-          set -euo pipefail
-          # The VFS shim is an LD_PRELOAD libc interceptor and is therefore
-          # libc-specific: on Linux it builds against gnu (VFS_TARGET) so it can
-          # preload into the host distro's glibc programs. macOS/Windows have no
-          # vfs_target, so VFS_TARGET falls back to the core target there.
-          # The mount features are what make the shipped driver able to serve a
-          # projection the operating system mounts, rather than only the
-          # injected shim. macOS gets nfs because it carries an NFS client in
-          # the base system; Linux gets fuse below because it carries libfuse
-          # far more widely than a configured NFS client. Neither flag moves the
-          # glibc floor or adds a runtime dependency: building the same tree
-          # with and without them yields an identical shared-library set and an
-          # identical set of referenced GLIBC symbol versions, and fuser links
-          # no library because it mounts through the fusermount3 helper.
-          # --locked still holds: nfsserve and fuser are already in kin-vfs's
-          # tracked lock at the pinned ref.
-          if [ "$RUNNER_OS" != "Linux" ]; then
-            cargo build --locked --release --target "$VFS_TARGET" -p kin-vfs-cli --features nfs
-            cargo build --locked --release --target "$VFS_TARGET" -p kin-vfs-shim
-            exit 0
-          fi
-          # The floor is read out of the guard rather than written here as
-          # well. A build targeting one floor while the guard enforces another
-          # is worse than no guard, and the two drifting apart is exactly the
-          # shape that survives review.
-          floor="$(node "$GITHUB_WORKSPACE/scripts/check-glibc-floor.mjs" --print-floor)"
-          # zig cc does not search Debian/Ubuntu multiarch directories, and the
-          # OpenSSL that kin-vfs-daemon links through reqwest lives in them:
-          # the headers under /usr/include/<multiarch> and the link libraries
-          # under /usr/lib/<multiarch>. Both Linux legs build natively, so the
-          # multiarch triple is the VFS target's architecture.
-          multiarch="${VFS_TARGET%%-*}-linux-gnu"
-          scoped="$(printf '%s' "$VFS_TARGET" | tr - _)"
-          upper="$(printf '%s' "$scoped" | tr '[:lower:]' '[:upper:]')"
-          export "CFLAGS_${scoped}=-I/usr/include/${multiarch}"
-          export "CARGO_TARGET_${upper}_RUSTFLAGS=-L native=/usr/lib/${multiarch}"
-          cargo zigbuild --locked --release --target "${VFS_TARGET}.${floor}" -p kin-vfs-cli --features fuse
-          cargo zigbuild --locked --release --target "${VFS_TARGET}.${floor}" -p kin-vfs-shim
-        env:
-          VFS_TARGET: ${{ matrix.vfs_target || matrix.target }}
-
-      - name: Build kin-vfs (cross)
-        if: ${{ matrix.cross }}
-        working-directory: kin-vfs
-        run: |
-          cross build --locked --release --target "$TARGET" -p kin-vfs-cli
-          cross build --locked --release --target "$TARGET" -p kin-vfs-shim
-        env:
-          TARGET: ${{ matrix.target }}
-
       - name: Verify native release build provenance
         if: ${{ !matrix.cross }}
         shell: bash
@@ -1004,12 +833,6 @@ jobs:
             echo "::error::release build mutated the source checkout"
             exit 1
           fi
-          vfs_dirty="$(git -C kin-vfs status --porcelain --untracked-files=all)"
-          if [ -n "$vfs_dirty" ]; then
-            printf '%s\n' "$vfs_dirty" >&2
-            echo "::error::release build mutated the pinned kin-vfs checkout"
-            exit 1
-          fi
 
       # --- macOS code signing + notarization -------------------------------
       # Tag releases fail closed when signing/notarization credentials are not
@@ -1077,9 +900,7 @@ jobs:
         run: |
           for f in \
             "target/${TARGET}/release/kin" \
-            "target/${TARGET}/release/kin-daemon" \
-            "kin-vfs/target/${TARGET}/release/kin-vfs" \
-            "kin-vfs/target/${TARGET}/release/${SHIM_NAME}"; do
+            "target/${TARGET}/release/kin-daemon"; do
             test -f "$f"
             codesign --force --options runtime --timestamp \
               --sign "$MACOS_DEVELOPER_ID" "$f"
@@ -1096,7 +917,6 @@ jobs:
         env:
           MACOS_DEVELOPER_ID: ${{ secrets.MACOS_DEVELOPER_ID }}
           TARGET: ${{ matrix.target }}
-          SHIM_NAME: ${{ matrix.shim_name }}
 
       # Zip the signed Mach-O binaries for notarization. Apple Notary accepts a
       # zip of standalone executables/dylibs (the same input notarytool takes);
@@ -1111,9 +931,7 @@ jobs:
           FILES=()
           for f in \
             "target/${TARGET}/release/kin" \
-            "target/${TARGET}/release/kin-daemon" \
-            "kin-vfs/target/${TARGET}/release/kin-vfs" \
-            "kin-vfs/target/${TARGET}/release/${SHIM_NAME}"; do
+            "target/${TARGET}/release/kin-daemon"; do
             [ -f "$f" ] && FILES+=("$f")
           done
           zip -j "$NOTARIZE_ZIP" "${FILES[@]}"
@@ -1123,7 +941,6 @@ jobs:
           ( cd "target/${TARGET}/release" && zip -qr "$OLDPWD/$NOTARIZE_ZIP" KinNotifier.app )
         env:
           TARGET: ${{ matrix.target }}
-          SHIM_NAME: ${{ matrix.shim_name }}
           ARTIFACT: ${{ matrix.artifact }}
 
       # Fallback / default backend: notarize inline on the macOS runner. Runs
@@ -1172,10 +989,6 @@ jobs:
           # archive lets `kin init` succeed but then `kin status`/`kin search`
           # fail with no daemon on PATH, so a missing daemon must fail the build.
           cp "target/${TARGET}/release/kin-daemon" "$ARTIFACT/"
-          # kin-vfs (cli + shim) is built under VFS_TARGET, which on Linux is the
-          # gnu triple (the shim is libc-specific) and elsewhere equals TARGET.
-          cp "kin-vfs/target/${VFS_TARGET}/release/kin-vfs" "$ARTIFACT/"
-          cp "kin-vfs/target/${VFS_TARGET}/release/${SHIM_NAME}" "$ARTIFACT/"
           # KinNotifier.app is macOS-only and is copied whole: -R preserves the
           # bundle structure and the stapled notarization ticket inside it.
           if [ -d "target/${TARGET}/release/KinNotifier.app" ]; then
@@ -1183,8 +996,8 @@ jobs:
           fi
           # Words, not just executables. Both arms of the isolated stranger run
           # installed this archive successfully and both scored the packaging
-          # below the binaries, because nothing in it says where the three
-          # executables go or that the shared library belongs somewhere else.
+          # below the binaries, because nothing in it says where the two
+          # executables go or that the daemon belongs beside the CLI.
           node scripts/write-release-archive-docs.mjs "$ARTIFACT" "$TARGET" "${GITHUB_REF_NAME#v}"
           tar czf "${ARTIFACT}.tar.gz" "$ARTIFACT"
           # Take the listing once into a file. Piping it into `grep -q` lets grep
@@ -1194,7 +1007,7 @@ jobs:
           ARCHIVE_LISTING="$RUNNER_TEMP/${ARTIFACT}.listing.txt"
           tar tzf "${ARTIFACT}.tar.gz" > "$ARCHIVE_LISTING"
           # All supported Unix surfaces are mandatory release contents.
-          for required in kin kin-daemon kin-vfs "$SHIM_NAME" README.md INSTALL.md checksums-sha256.txt; do
+          for required in kin kin-daemon README.md INSTALL.md checksums-sha256.txt; do
             if ! grep -q "/${required}$" "$ARCHIVE_LISTING"; then
               echo "::error::$required missing from ${ARTIFACT}.tar.gz"
               exit 1
@@ -1212,24 +1025,7 @@ jobs:
           shasum -a 256 "${ARTIFACT}.tar.gz" > "${ARTIFACT}.tar.gz.sha256"
         env:
           TARGET: ${{ matrix.target }}
-          VFS_TARGET: ${{ matrix.vfs_target || matrix.target }}
           ARTIFACT: ${{ matrix.artifact }}
-          SHIM_NAME: ${{ matrix.shim_name }}
-
-      # Read the floor back off the bytes that were just packaged. The build
-      # above pins it, and a pin goes quiet the day it stops taking effect,
-      # which is how v0.5.38 published a kin-vfs that no Debian 12 could start
-      # while every check in this workflow stayed green. This step is the half
-      # that cannot pass by accident: it names the highest GLIBC requirement in
-      # each shipped dynamic binary and the symbols that set it, and refuses the
-      # release above the floor.
-      - name: Verify the packaged Linux binaries meet the published glibc floor
-        if: ${{ runner.os == 'Linux' && !matrix.skip_vfs }}
-        shell: bash
-        run: node scripts/check-glibc-floor.mjs "$ARTIFACT/kin-vfs" "$ARTIFACT/$SHIM_NAME"
-        env:
-          ARTIFACT: ${{ matrix.artifact }}
-          SHIM_NAME: ${{ matrix.shim_name }}
 
       - name: Package (Windows)
         if: runner.os == 'Windows'
@@ -1240,8 +1036,6 @@ jobs:
           # kin-daemon is mandatory: fail hard if it's missing rather
           # than ship a daemon-less archive that can `kin init` but nothing else.
           Copy-Item "target/$env:TARGET/release/kin-daemon.exe" "$env:ARTIFACT/" -ErrorAction Stop
-          Copy-Item "kin-vfs/target/$env:TARGET/release/kin-vfs.exe" "$env:ARTIFACT/" -ErrorAction SilentlyContinue
-          Copy-Item "kin-vfs/target/$env:TARGET/release/$env:SHIM_NAME" "$env:ARTIFACT/" -ErrorAction SilentlyContinue
           # See the Unix leg: the archive carries its own README, INSTALL and
           # checksum manifest so a stranger is not guessing at layout.
           node scripts/write-release-archive-docs.mjs "$env:ARTIFACT" "$env:TARGET" ($env:GITHUB_REF_NAME -replace '^v', '')
@@ -1319,15 +1113,12 @@ jobs:
         env:
           TARGET: ${{ matrix.target }}
           ARTIFACT: ${{ matrix.artifact }}
-          SHIM_NAME: ${{ matrix.shim_name }}
 
       - name: Generate artifact provenance manifest
         shell: bash
         env:
           ARTIFACT: ${{ matrix.artifact }}
           TARGET: ${{ matrix.target }}
-          VFS_TARGET: ${{ matrix.vfs_target || matrix.target }}
-          EXPECTED_VFS_COMMIT: 199818f0d1d9ff934de76b73b353183352db08b3
         run: |
           set -euo pipefail
           node <<'NODE'
@@ -1352,14 +1143,7 @@ jobs:
             childProcess.execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
 
           const kinCommit = git(root, "rev-parse", "HEAD");
-          const vfsRoot = path.join(root, "kin-vfs");
-          const vfsCommit = git(vfsRoot, "rev-parse", "HEAD");
-          if (vfsCommit !== process.env.EXPECTED_VFS_COMMIT) {
-            throw new Error(`kin-vfs checkout ${vfsCommit} does not match pinned ${process.env.EXPECTED_VFS_COMMIT}`);
-          }
-
           const kinLockSha = sha256(path.join(root, "Cargo.lock"));
-          const vfsLockSha = sha256(path.join(vfsRoot, "Cargo.lock"));
           const buildMetaPath = path.join(
             process.env.RUNNER_TEMP,
             `kin-release-provenance-${target}`,
@@ -1449,16 +1233,10 @@ jobs:
             release_tag: process.env.GITHUB_REF_NAME,
             artifact,
             target,
-            vfs_target: process.env.VFS_TARGET,
             kin: {
               commit: kinCommit,
               cargo_lock_sha256: kinLockSha,
               embedded_dependency_provenance: buildMeta.dependency_provenance,
-            },
-            kin_vfs: {
-              commit: vfsCommit,
-              dirty: false,
-              cargo_lock_sha256: vfsLockSha,
             },
             archive: archiveRecord(archive),
             ...(additionalArchiveNames.length
@@ -1614,14 +1392,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Checkout pinned kin-vfs provenance source
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          repository: firelock-ai/kin-vfs
-          path: release-inputs/kin-vfs
-          ref: 199818f0d1d9ff934de76b73b353183352db08b3
-          persist-credentials: false
-
       - name: Download all artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.0
         with:
@@ -1722,8 +1492,6 @@ jobs:
         run: python3 ./scripts/verify-installer-release-assets.py --assets-dir .
 
       - name: Verify and aggregate release provenance
-        env:
-          EXPECTED_VFS_COMMIT: 199818f0d1d9ff934de76b73b353183352db08b3
         run: |
           set -euo pipefail
           node <<'NODE'
@@ -1777,29 +1545,25 @@ jobs:
               artifact: "kin-linux-x86_64",
               archive: "kin-linux-x86_64.tar.gz",
               target: "x86_64-unknown-linux-musl",
-              vfsTarget: "x86_64-unknown-linux-gnu",
-              required: ["kin", "kin-daemon", "kin-vfs", "libkin_vfs_shim.so"],
+              required: ["kin", "kin-daemon"],
             },
             {
               artifact: "kin-linux-aarch64",
               archive: "kin-linux-aarch64.tar.gz",
               target: "aarch64-unknown-linux-musl",
-              vfsTarget: "aarch64-unknown-linux-gnu",
-              required: ["kin", "kin-daemon", "kin-vfs", "libkin_vfs_shim.so"],
+              required: ["kin", "kin-daemon"],
             },
             {
               artifact: "kin-macos-x86_64",
               archive: "kin-macos-x86_64.tar.gz",
               target: "x86_64-apple-darwin",
-              vfsTarget: "x86_64-apple-darwin",
-              required: ["kin", "kin-daemon", "kin-vfs", "libkin_vfs_shim.dylib"],
+              required: ["kin", "kin-daemon"],
             },
             {
               artifact: "kin-macos-aarch64",
               archive: "kin-macos-aarch64.tar.gz",
               target: "aarch64-apple-darwin",
-              vfsTarget: "aarch64-apple-darwin",
-              required: ["kin", "kin-daemon", "kin-vfs", "libkin_vfs_shim.dylib"],
+              required: ["kin", "kin-daemon"],
             },
             {
               artifact: "kin-windows-x86_64",
@@ -1810,18 +1574,12 @@ jobs:
               // drift into shipping different bytes under one release.
               additionalArchives: ["kin-windows-x86_64.tar.gz"],
               target: "x86_64-pc-windows-msvc",
-              vfsTarget: "x86_64-pc-windows-msvc",
               required: ["kin.exe", "kin-daemon.exe"],
             },
           ];
 
           const kinCommit = git(root, "rev-parse", "HEAD");
           const kinLockSha = sha256(path.join(root, "Cargo.lock"));
-          const vfsRoot = path.join(root, "release-inputs", "kin-vfs");
-          const vfsCommit = git(vfsRoot, "rev-parse", "HEAD");
-          const vfsLockSha = sha256(path.join(vfsRoot, "Cargo.lock"));
-          fail(vfsCommit === process.env.EXPECTED_VFS_COMMIT,
-            `kin-vfs checkout ${vfsCommit} does not match pinned ${process.env.EXPECTED_VFS_COMMIT}`);
 
           const artifacts = specs.map((spec) => {
             const manifestPath = `${spec.artifact}.provenance.json`;
@@ -1831,18 +1589,11 @@ jobs:
               `${manifestPath} release tag does not match ${process.env.GITHUB_REF_NAME}`);
             fail(manifest.artifact === spec.artifact, `${manifestPath} artifact identity is wrong`);
             fail(manifest.target === spec.target, `${manifestPath} target identity is wrong`);
-            fail(manifest.vfs_target === spec.vfsTarget, `${manifestPath} kin-vfs target identity is wrong`);
             fail(manifest.kin?.commit === kinCommit, `${manifestPath} Kin commit does not match the tag`);
             fail(manifest.kin?.cargo_lock_sha256 === kinLockSha,
               `${manifestPath} Kin Cargo.lock hash does not match the tag`);
             fail(manifest.kin?.embedded_dependency_provenance === kinLockSha,
               `${manifestPath} embedded dependency provenance does not match the tagged Cargo.lock`);
-            fail(manifest.kin_vfs?.commit === vfsCommit,
-              `${manifestPath} kin-vfs commit does not match the pinned checkout`);
-            fail(manifest.kin_vfs?.dirty === false,
-              `${manifestPath} does not certify a clean kin-vfs checkout`);
-            fail(manifest.kin_vfs?.cargo_lock_sha256 === vfsLockSha,
-              `${manifestPath} kin-vfs Cargo.lock hash does not match the pinned checkout`);
             fail(manifest.archive?.name === spec.archive, `${manifestPath} archive name is wrong`);
             fail(manifest.archive?.sha256 === sha256(spec.archive),
               `${manifestPath} archive hash does not match the final archive`);
@@ -1980,7 +1731,6 @@ jobs:
             schema_version: 2,
             release_tag: process.env.GITHUB_REF_NAME,
             kin: { commit: kinCommit, cargo_lock_sha256: kinLockSha },
-            kin_vfs: { commit: vfsCommit, dirty: false, cargo_lock_sha256: vfsLockSha },
             artifacts,
             workflow: {
               repository: process.env.GITHUB_REPOSITORY,
@@ -2097,7 +1847,6 @@ jobs:
     uses: ./.github/workflows/install-proof.yml
     with:
       release_tag: ${{ github.ref_name }}
-      expected_vfs_commit: 199818f0d1d9ff934de76b73b353183352db08b3
     permissions:
       contents: read
       attestations: read

--- a/crates/kin-agent/src/run.rs
+++ b/crates/kin-agent/src/run.rs
@@ -1121,10 +1121,7 @@ pub fn run(config: AgentConfig) -> anyhow::Result<RunOutcome> {
                                                         provenance,
                                                     )
                                                 }
-                                            } else if servers[index]
-                                                .declares("kin_transaction_begin")
-                                                && servers[index].declares("kin_transaction_stage")
-                                            {
+                                            } else {
                                                 // Kin is attached and no transaction opened,
                                                 // so nothing is written: a local write here is
                                                 // a change on disk the graph never hears about,
@@ -1147,63 +1144,6 @@ pub fn run(config: AgentConfig) -> anyhow::Result<RunOutcome> {
                                                     ),
                                                     provenance,
                                                 )
-                                            } else {
-                                                let mut outcome = match tool {
-                                                    LocalTool::Edit => {
-                                                        belt::run_edit(&repo, &call.arguments)
-                                                    }
-                                                    LocalTool::Write => {
-                                                        belt::run_write(&repo, &call.arguments)
-                                                    }
-                                                };
-                                                // Stage what the harness just did, inside
-                                                // the open bracket, so the commit below
-                                                // has something to publish. An empty
-                                                // transaction is refused by design.
-                                                let staged = if outcome.is_error {
-                                                    false
-                                                } else {
-                                                    stage_planned_operation(
-                                                        &mut servers[index],
-                                                        &mut bracket,
-                                                        session.as_deref(),
-                                                        &plan,
-                                                        outcome.body.as_deref(),
-                                                        &mut writer,
-                                                    )?
-                                                };
-                                                let wanted_publication =
-                                                    !outcome.is_error && staged;
-                                                let provenance = close_transaction(
-                                                    &mut servers[index],
-                                                    bracket,
-                                                    wanted_publication,
-                                                    &mut writer,
-                                                )?;
-                                                if wanted_publication
-                                                    && !published_by_authority(&provenance)
-                                                {
-                                                    counters.unpublished_changes += 1;
-                                                    // The model has to hear this. A bare
-                                                    // success reads as "the edit reached
-                                                    // the graph", and it did not: the
-                                                    // change is on disk and the
-                                                    // transaction aborted. The create
-                                                    // branch has said so since kin#1082,
-                                                    // and this branch had no traffic at
-                                                    // all until an edit could stage.
-                                                    if !outcome.is_error {
-                                                        outcome.text = format!(
-                                                            "{} Repository authority did \
-                                                             not publish it: {}. The \
-                                                             change is on disk and \
-                                                             uncommitted.",
-                                                            outcome.text,
-                                                            unpublished_reason(&provenance),
-                                                        );
-                                                    }
-                                                }
-                                                (outcome, provenance)
                                             };
                                             if let Some(path) = outcome.changed.clone() {
                                                 // With several repositories attached the
@@ -1687,7 +1627,7 @@ fn start_kin_session(
             "server": server_name,
             "policy": "allowed",
             "event": "session_unavailable",
-            "detail": "the server does not expose kin_session_start; edits will carry no session provenance",
+            "detail": "the server does not expose kin_session_start; local writing tools will refuse changes",
         }))?;
         return Ok(None);
     }
@@ -1892,7 +1832,12 @@ fn begin_transaction(
     let Some(session) = session else {
         return Ok(Bracket::unopened("no Kin session was open"));
     };
-    for required in ["kin_transaction_begin", "kin_transaction_stage"] {
+    for required in [
+        "kin_transaction_begin",
+        "kin_transaction_stage",
+        "kin_transaction_commit",
+        "kin_transaction_abort",
+    ] {
         if !server.declares(required) {
             return Ok(Bracket::unopened(format!(
                 "the server does not expose {required}"

--- a/crates/kin-agent/tests/loop_integration.rs
+++ b/crates/kin-agent/tests/loop_integration.rs
@@ -210,6 +210,90 @@ fn write_fake_mcp_server(dir: &Path) -> PathBuf {
     path
 }
 
+/// Search-only profiles and incomplete transaction surfaces must never turn a local
+/// writing tool into an untracked filesystem edit.
+#[test]
+fn incomplete_publication_surface_refuses_edit_and_create_without_changing_files() {
+    for missing in [
+        "all",
+        "kin_session_start",
+        "kin_transaction_begin",
+        "kin_transaction_stage",
+        "kin_transaction_commit",
+        "kin_transaction_abort",
+    ] {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = fixture_repo(dir.path());
+        let original = std::fs::read(repo.join("src/greet.py")).unwrap();
+        let server = dir.path().join("incomplete_mcp.py");
+        let filter = if missing == "all" {
+            "TOOLS = [t for t in TOOLS if not t['name'].startswith('kin_')]".to_string()
+        } else {
+            format!("TOOLS = [t for t in TOOLS if t['name'] != '{missing}']")
+        };
+        std::fs::write(
+            &server,
+            FAKE_SERVER.replace("ENVELOPE =", &format!("{filter}\n\nENVELOPE =")),
+        )
+        .unwrap();
+        let log = dir.path().join("mcp-calls.jsonl");
+        let endpoint = FakeEndpoint::start(vec![
+            completion(
+                "Editing.",
+                Some(tool_call(
+                    "e1",
+                    "edit_file",
+                    json!({
+                        "path": "src/greet.py", "find": "hello", "replace": "goodbye"
+                    }),
+                )),
+            ),
+            completion(
+                "Creating.",
+                Some(tool_call(
+                    "w1",
+                    "write_file",
+                    json!({
+                        "path": "src/new.py", "content": "def created():\n    return 1\n"
+                    }),
+                )),
+            ),
+            completion("Both changes landed.", None),
+        ]);
+        let outcome = kin_agent::run(config(
+            &repo,
+            &dir.path().join("out"),
+            &endpoint.base_url,
+            mcp_command(&server, &log),
+        ))
+        .unwrap();
+        assert_eq!(
+            std::fs::read(repo.join("src/greet.py")).unwrap(),
+            original,
+            "missing {missing}"
+        );
+        assert!(!repo.join("src/new.py").exists(), "missing {missing}");
+        assert_eq!(
+            outcome.status,
+            ExitStatus::ChangesUnpublished,
+            "missing {missing}"
+        );
+        assert_eq!(outcome.result["kin_agent"]["unpublished_changes"], 2);
+        let analyzed = analyze(&read_jsonl(&outcome.transcript_path));
+        assert_eq!(analyzed.tool_results.len(), 2);
+        assert!(analyzed
+            .tool_results
+            .iter()
+            .all(|(_, text, error)| *error && text.contains("was not changed")));
+        assert!(
+            !mcp_log(&log)
+                .iter()
+                .any(|row| row["tool"] == "kin_transaction_begin"),
+            "an incomplete surface must not open a transaction: missing {missing}"
+        );
+    }
+}
+
 const FAKE_SERVER: &str = r#"#!/usr/bin/env python3
 import json, os, sys, time
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1375,10 +1375,17 @@ third of the idle window the session reply named in `idle_timeout_secs`, so a tu
 than that window does not cost the run its session. A reply that names no window gets no
 heartbeat rather than a guessed one. The result record counts them in `session_heartbeats`.
 
+The local `edit_file` and `write_file` tools publish through a Kin session and transaction.
+They require the server to expose session start plus transaction begin, stage, commit and
+abort. A query-only or search-only profile that omits those tools refuses the change before
+writing any file, returns an error to the model and increments `unpublished_changes`.
+Use `agent-default` for native agent tasks that need these writing tools. Discovering a
+transaction tool later does not provision the harness's publication session.
+
 The exit code is the run's outcome: `0` a final answer, `1` a harness error, `2` the
 tool-call budget was spent, `3` the deadline expired, `4` the endpoint was unreachable or
-answered with nothing usable, `5` the MCP server failed, `6` the run changed files that
-repository authority never published, `7` the conversation reached the model's context
+answered with nothing usable, `5` the MCP server failed, `6` requested changes were not
+published by repository authority, `7` the conversation reached the model's context
 window. A transcript is written and closed on every one of them, so a failed run is still
 measurable.
 

--- a/scripts/release-archive-shape.cjs
+++ b/scripts/release-archive-shape.cjs
@@ -43,17 +43,14 @@ const MAX_BUNDLE_DEPTH = 6;
 // The set is an upper bound rather than a checklist. Which components are
 // mandatory is decided by the packaging step's own presence assertions and by
 // the publish job's per-artifact required list; what this decides is only which
-// names may appear at all, which is why the Windows projection components sit
-// here even though that leg ships them opportunistically. Adding a component to
-// a release archive means adding it to the updater's platform component list
-// and to this set together.
+// names may appear at all. Adding a component to a release archive means adding
+// it to the updater's platform component list and to this set together.
 // Documentation members every archive carries, on every platform.
 //
 // The v0.5.40 archive was four executables and no words, and both strangers who
 // installed it scored the packaging below the binaries for exactly that reason.
-// A stranger's first two decisions, where the three executables go and what to
-// do with the shared library, are both unguided, and no `kin` command can
-// advise them before `kin` is on PATH. These three files are the answer that
+// A stranger must decide where the two executable runtime files go before
+// `kin` is on PATH and can offer advice. These three files are the answer that
 // travels with the bytes.
 //
 // They are members of the archive and nothing installs them: `kin update` skips
@@ -70,21 +67,9 @@ const MAX_BUNDLE_DEPTH = 6;
 const DOC_FILES = Object.freeze(["README.md", "INSTALL.md", "checksums-sha256.txt"]);
 
 const ROOT_FILES_BY_FAMILY = {
-  darwin: Object.freeze([
-    "kin",
-    "kin-daemon",
-    "kin-vfs",
-    "libkin_vfs_shim.dylib",
-    ...DOC_FILES,
-  ]),
-  linux: Object.freeze(["kin", "kin-daemon", "kin-vfs", "libkin_vfs_shim.so", ...DOC_FILES]),
-  windows: Object.freeze([
-    "kin.exe",
-    "kin-daemon.exe",
-    "kin-vfs.exe",
-    "kin_vfs_shim.dll",
-    ...DOC_FILES,
-  ]),
+  darwin: Object.freeze(["kin", "kin-daemon", ...DOC_FILES]),
+  linux: Object.freeze(["kin", "kin-daemon", ...DOC_FILES]),
+  windows: Object.freeze(["kin.exe", "kin-daemon.exe", ...DOC_FILES]),
 };
 
 // Whether a target triple is one whose archive may carry the notification

--- a/scripts/release-archive-shape.test.cjs
+++ b/scripts/release-archive-shape.test.cjs
@@ -25,15 +25,12 @@ const MACOS_ARTIFACT = "kin-macos-x86_64";
 const LINUX_ARTIFACT = "kin-linux-x86_64";
 const WINDOWS_ARTIFACT = "kin-windows-x86_64";
 
-// Verbatim `tar -tzf kin-macos-x86_64.tar.gz` output from the release build that
-// this guard rejected, including its interleaved directory records and the
-// bundle's signature payload. Fixtures are derived from it rather than from an
-// idealized listing so the accepted shape is the shape a release actually has.
+// The future macOS archive shape, including its interleaved directory records
+// and the bundle's signature payload. Fixtures model the archive layout the
+// release workflow must publish, not a hand-picked subset of its files.
 const MACOS_LISTING = [
   "kin-macos-x86_64/",
   "kin-macos-x86_64/kin",
-  "kin-macos-x86_64/kin-vfs",
-  "kin-macos-x86_64/libkin_vfs_shim.dylib",
   "kin-macos-x86_64/KinNotifier.app/",
   "kin-macos-x86_64/kin-daemon",
   "kin-macos-x86_64/KinNotifier.app/Contents/",
@@ -47,18 +44,16 @@ const MACOS_LISTING = [
   "kin-macos-x86_64/KinNotifier.app/Contents/_CodeSignature/CodeResources",
 ];
 
-// The same archive one release earlier, before the notification bundle shipped.
+// Linux archives have no bundle and carry only the supported runtime pair.
 const LINUX_LISTING = [
   "kin-linux-x86_64/",
   "kin-linux-x86_64/kin",
-  "kin-linux-x86_64/kin-vfs",
-  "kin-linux-x86_64/libkin_vfs_shim.so",
   "kin-linux-x86_64/kin-daemon",
 ];
 
 // The Windows zip is compressed from `<artifact>/*`, so its members carry no
 // artifact prefix at all.
-const WINDOWS_LISTING = ["kin.exe", "kin-daemon.exe", "kin-vfs.exe"];
+const WINDOWS_LISTING = ["kin.exe", "kin-daemon.exe"];
 
 // Documentation members ride on every family, so the per-family admitted root
 // sets below are the components plus these, sorted. They are admitted at the
@@ -66,11 +61,9 @@ const WINDOWS_LISTING = ["kin.exe", "kin-daemon.exe", "kin-vfs.exe"];
 // inventory by its own component list and refuses any other name, which is how
 // v0.6.2 refused v0.6.3 on `checksums-sha256.txt`.
 const DOC_FILES = ["INSTALL.md", "README.md", "checksums-sha256.txt"].sort();
-const MACOS_COMPONENTS = ["kin", "kin-daemon", "kin-vfs", "libkin_vfs_shim.dylib"].sort();
-const LINUX_COMPONENTS = ["kin", "kin-daemon", "kin-vfs", "libkin_vfs_shim.so"].sort();
-// Sorted the way the classifier returns names, which puts the bare CLI between
-// the hyphenated binaries and the underscored shim.
-const WINDOWS_COMPONENTS = ["kin-daemon.exe", "kin-vfs.exe", "kin.exe", "kin_vfs_shim.dll"].sort();
+const MACOS_COMPONENTS = ["kin", "kin-daemon"].sort();
+const LINUX_COMPONENTS = ["kin", "kin-daemon"].sort();
+const WINDOWS_COMPONENTS = ["kin-daemon.exe", "kin.exe"].sort();
 const MACOS_FILES = [...MACOS_COMPONENTS, ...DOC_FILES].sort();
 const LINUX_FILES = [...LINUX_COMPONENTS, ...DOC_FILES].sort();
 const WINDOWS_FILES = [...WINDOWS_COMPONENTS, ...DOC_FILES].sort();
@@ -128,11 +121,30 @@ test("a macOS target carries the bundle and no other target does", () => {
   assert.throws(() => targetCarriesNotifierBundle(""), /requires a target triple/);
 });
 
-test("the released macOS archive listing is accepted whole", () => {
+test("the supported macOS archive listing is accepted whole", () => {
   assertReleaseArchiveMemberPaths(MACOS_LISTING, {
     artifact: MACOS_ARTIFACT,
     target: MACOS_TARGET,
   });
+});
+
+test("deprecated VFS binaries and shims are refused on every platform", () => {
+  const cases = [
+    [MACOS_LISTING, MACOS_ARTIFACT, MACOS_TARGET, "kin-vfs"],
+    [MACOS_LISTING, MACOS_ARTIFACT, MACOS_TARGET, "libkin_vfs_shim.dylib"],
+    [LINUX_LISTING, LINUX_ARTIFACT, LINUX_TARGET, "kin-vfs"],
+    [LINUX_LISTING, LINUX_ARTIFACT, LINUX_TARGET, "libkin_vfs_shim.so"],
+    [WINDOWS_LISTING, WINDOWS_ARTIFACT, WINDOWS_TARGET, "kin-vfs.exe"],
+    [WINDOWS_LISTING, WINDOWS_ARTIFACT, WINDOWS_TARGET, "kin_vfs_shim.dll"],
+  ];
+  for (const [listing, artifact, target, retired] of cases) {
+    const member = target.includes("-windows-") ? retired : `${artifact}/${retired}`;
+    assert.throws(
+      () => assertReleaseArchiveMemberPaths([...listing, member], { artifact, target }),
+      /declares unexpected file/,
+      `${target} archive admitted retired ${retired}`
+    );
+  }
 });
 
 test("prefixed Unix and unprefixed Windows listings are both accepted", () => {

--- a/scripts/release-proof/VENDORED.json
+++ b/scripts/release-proof/VENDORED.json
@@ -1,12 +1,12 @@
 {
   "source_repository": "firelock-ai/kin-ecosystem",
   "source_commit": "c1cbeeb25f6070e59178badb401e9195537d91de",
-  "note": "Byte-identical copies of the umbrella proof tooling so the hosted preflight runs from kin alone; bin/kin-lane is a single-host lock shim written for this tree, not a copy. scripts/release-proof/vendored.test.mjs refuses a file whose sha256 left this manifest. One exception stands against source_commit: bin/kin-release-preflight.d/validate.mjs carries a PORTED_FROM pin restamped in kin first, because kin#1652 moved install-proof.yml and the preflight then refused all three legs of the v0.7.9 cut on the stale pin. kin-ecosystem needs the same one-line restamp before the next re-vendor overwrites it. A second exception stands against source_commit the other way: bin/kin-release-preflight.d/proof-flow.sh carries the bytes of kin-ecosystem's proof-flow exit-tolerance change (branch chore/lane-prefrc-kin-ecosystem-proof-flow at 434dcf75321f03195d005d35895120f5e9010015, sha256 943160af), vendored into kin AHEAD of that change landing on the umbrella's main. The order is forced: the umbrella's own parity check requires kin to carry identical bytes before its pull request can go green, so kin vendors first and the umbrella lands second.",
+  "note": "The hashes are the authority for the exact proof bytes this tree runs. source_commit identifies the last umbrella vendor snapshot. bin/kin-lane is local to this tree. bin/kin-release-preflight, bin/kin-release-preflight.d/proof-flow.sh, and bin/kin-release-preflight.d/validate.mjs carry the Kin-side VFS retirement update: future release packages omit the external kin-vfs executable and preload shims while complete legacy archives remain verifiable. Re-vendor the corresponding umbrella update before calling those copies byte-identical again.",
   "files": {
-    "bin/kin-release-preflight": {"source": "bin/kin-release-preflight", "sha256": "aedf49d66f774ff5fc34c84a4efccbe913278478281ece0917d50b8d910dd235"},
+    "bin/kin-release-preflight": {"source": "bin/kin-release-preflight", "sha256": "71ca13cdcacde94c1f1cbc67aa351f3bb7c7b13eb0ad525fc6c82bc4d9c302cd"},
     "bin/kin-release-preflight.d/Dockerfile": {"source": "bin/kin-release-preflight.d/Dockerfile", "sha256": "e6c0e30c2bf46fc889484fb7e32c73163c3cf315d60351be3acd2428d22d12f6"},
-    "bin/kin-release-preflight.d/proof-flow.sh": {"source": "bin/kin-release-preflight.d/proof-flow.sh", "sha256": "943160afa4bb1f2aa58e0e1639c1cb81dccba20e1566bec80757f452834b4ef1"},
-    "bin/kin-release-preflight.d/validate.mjs": {"source": "bin/kin-release-preflight.d/validate.mjs", "sha256": "fc9c482ce588b0c78d59e08dfda8382f1e31615592d721dcd00625c6ba0917a2"},
+    "bin/kin-release-preflight.d/proof-flow.sh": {"source": "bin/kin-release-preflight.d/proof-flow.sh", "sha256": "ea81918079bbe7662391836b2a1341471da4487a184ed6086e7450a7757f8738"},
+    "bin/kin-release-preflight.d/validate.mjs": {"source": "bin/kin-release-preflight.d/validate.mjs", "sha256": "0c991568dba0763781a08c66bf464dff247e77a62b0ab420edde6900cd5d48f9"},
     "bin/kin-evidence-publish": {"source": "bin/kin-evidence-publish", "sha256": "8912fd933ba37e2570ea2ff685a885551543f2a01e3baeb394876121f8811679"},
     "bin/kin-acceptance-suite": {"source": "bin/kin-acceptance-suite", "sha256": "7ce214e6563e227695cf02411762ca5e8d01edf8898634db465ee30f455918f7"}
   }

--- a/scripts/release-proof/bin/kin-release-preflight
+++ b/scripts/release-proof/bin/kin-release-preflight
@@ -13,8 +13,8 @@
 # with nothing local having ever asked the question. This tool asks it here:
 # the same flow, the same assertions, the same repro suite, against a build
 # from a worktree or an archive as shipped, on this host and inside a Debian 12
-# container for a Linux archive, with the glibc floor read off the packaged
-# kin-vfs and shim exactly as the release does.
+# container for a Linux archive. Legacy archives that still carry the retired
+# VFS pair retain their own compatibility proof.
 #
 # DEV-LOCAL. NON-CITABLE. The publish-fetch surface (get.kinlab.dev, the
 # attestation, the tag binding, the provenance manifest) is not exercised, and
@@ -63,13 +63,13 @@ What it judges, and where:
                       builds through `bin/kin-lane run <lane> kin -- cargo build`, any
                       other checkout builds in place with --locked --release), then
                       overlay them onto the newest published archive for this host
-                      (kin-vfs, the shim and KinNotifier.app come from that base) and
-                      prove the result on the host
+                      (KinNotifier.app comes from that base), remove retired VFS
+                      runtime artifacts, and prove the result on the host
   --bin/--daemon      the same, from binaries you already built
   --archive FILE      a release-shaped archive as shipped. The host's own target runs
                       on the host; a Linux archive runs inside a Debian 12 container
-                      of its architecture (linux/arm64 for kin-linux-aarch64), where the
-                      glibc floor guard also runs on kin-vfs and the shim. Repeat the
+                      of its architecture (linux/arm64 for kin-linux-aarch64). A legacy
+                      archive retains its VFS compatibility check. Repeat the
                       flag to judge several archives in one run
   --rc-run ID         download every kin-<os>-<arch>.tar.gz a kin rc-build.yml run
                       produced and judge each one as --archive would. This is how
@@ -86,7 +86,7 @@ Options:
   --base-archive FILE archive to overlay --build/--bin binaries onto (default: the newest
                       GitHub release's archive for this host, cached under
                       .kin-coord/preflight/base/<tag>/)
-  --kin-repo DIR      kin checkout supplying scripts/install.sh, check-glibc-floor.mjs
+  --kin-repo DIR      kin checkout supplying scripts/install.sh, archive documentation,
                       and the workflow the assertions were ported from (default: the
                       --build checkout, else <umbrella>/kin)
   --kin-ref REF       git ref of --kin-repo to take those files from (default: the
@@ -474,6 +474,8 @@ if [ -z "$BUILD_DIR" ] && [ -z "$KIN_REF" ]; then
 fi
 if [ -n "$KIN_REF" ]; then TOOL_SRC="$KIN_REPO @ $KIN_REF"; else TOOL_SRC="$KIN_REPO (working tree)"; fi
 read_kin_file scripts/install.sh "$RUN_ROOT/tools/install.sh" || die "scripts/install.sh not found at $TOOL_SRC"
+read_kin_file scripts/write-release-archive-docs.mjs "$RUN_ROOT/tools/write-release-archive-docs.mjs" \
+  || die "scripts/write-release-archive-docs.mjs not found at $TOOL_SRC"
 if read_kin_file scripts/check-glibc-floor.mjs "$RUN_ROOT/tools/check-glibc-floor.mjs"; then
   GLIBC_GUARD="present"
 else
@@ -487,10 +489,10 @@ PORTED_SHA="$(sed -n 's/^  sha256: "\([0-9a-f]\{64\}\)",$/\1/p' "$HELPERS/valida
 cp "$HELPERS/proof-flow.sh" "$RUN_ROOT/tools/proof-flow.sh"
 cp "$HELPERS/validate.mjs" "$RUN_ROOT/tools/validate.mjs"
 # The acceptance suite comes from kin, never from a copy kept here. A release
-# archive carries kin, kin-daemon, kin-vfs, the shim, README and INSTALL and no
+# archive carries kin, kin-daemon, README and INSTALL and no
 # scripts directory, so the bytes under test cannot supply their own checks;
 # the suite is pinned to the same KIN_REPO @ KIN_REF that already supplies
-# scripts/install.sh and check-glibc-floor.mjs. bin/kin-acceptance-suite prints
+# scripts/install.sh. bin/kin-acceptance-suite prints
 # the path, sha256 and tree sha it resolved, and refuses a copy that came from
 # outside that tree. The umbrella used to keep its own copy and it drifted six
 # checks behind kin's within two days, which is why there is one copy now.
@@ -518,7 +520,7 @@ else
   fi
 fi
 chmod +x "$RUN_ROOT/tools/proof-flow.sh" "$RUN_ROOT/tools/install.sh" 2>/dev/null
-say "tooling from $TOOL_SRC: install.sh, check-glibc-floor.mjs $GLIBC_GUARD"
+say "tooling from $TOOL_SRC: install.sh, archive docs, check-glibc-floor.mjs $GLIBC_GUARD"
 say "acceptance suite: $MAGIC_SRC"
 # validate.mjs is a hand port of install-proof.yml's "Validate installed
 # capability proof" block. When the two disagree, a PASS here is a PASS against
@@ -649,6 +651,16 @@ fetch_base_archive() { # prints the path of a base archive for the host target
   printf '%s\n' "$dest/kin-$HOST_TARGET.tar.gz"
 }
 
+archive_target_for_host() {
+  case "$HOST_TARGET" in
+    macos-aarch64) printf '%s\n' 'aarch64-apple-darwin' ;;
+    macos-x86_64) printf '%s\n' 'x86_64-apple-darwin' ;;
+    linux-aarch64) printf '%s\n' 'aarch64-unknown-linux-musl' ;;
+    linux-x86_64) printf '%s\n' 'x86_64-unknown-linux-musl' ;;
+    *) die "no Cargo target mapping for $HOST_TARGET" ;;
+  esac
+}
+
 if [ -n "$BUILT_KIN" ]; then
   kin_line="$("$BUILT_KIN" --version 2>&1 | tail -1)"
   daemon_line="$("$BUILT_DAEMON" --version 2>&1 | tail -1)"
@@ -670,6 +682,17 @@ if [ -n "$BUILT_KIN" ]; then
   [ "$(basename "$content_root")" = "kin-$HOST_TARGET" ] || die "base archive content root $(basename "$content_root") is not kin-$HOST_TARGET"
   cp "$BUILT_KIN" "$content_root/kin" && cp "$BUILT_DAEMON" "$content_root/kin-daemon" || die "overlay failed"
   chmod +x "$content_root/kin" "$content_root/kin-daemon"
+  # The newest published base may predate VFS retirement. This scratch archive
+  # models the prospective release, so remove only its copied retired runtime
+  # files and regenerate its in-archive documentation and checksum inventory.
+  rm -f "$content_root/kin-vfs" "$content_root/kin-vfs.exe" \
+    "$content_root/libkin_vfs_shim.so" "$content_root/libkin_vfs_shim.dylib" \
+    "$content_root/kin_vfs_shim.dll"
+  archive_target="$(archive_target_for_host)"
+  archive_version="$(printf '%s\n' "$kin_line" | awk '{print $2}')"
+  node "$RUN_ROOT/tools/write-release-archive-docs.mjs" \
+    "$content_root" "$archive_target" "$archive_version" \
+    || die "could not regenerate the prospective archive documentation"
   host_archive="$RUN_ROOT/dist/kin-$HOST_TARGET.tar.gz"
   ( cd "$assemble" && tar -czf "$host_archive" "kin-$HOST_TARGET" ) || die "could not assemble $host_archive"
   rm -rf "$assemble"
@@ -689,7 +712,7 @@ if [ -n "$BUILT_KIN" ]; then
   kin-daemon:   $BUILT_DAEMON
                 sha256 $(sha256_of "$BUILT_DAEMON")
                 $daemon_line
-  base archive: $base (sha256 $base_sha) supplies kin-vfs, the shim and KinNotifier.app; kin and kin-daemon were overlaid onto it, so the assembled archive is neither a release nor a reproducible build
+  base archive: $base (sha256 $base_sha) supplies KinNotifier.app; kin and kin-daemon were overlaid and retired VFS runtime artifacts removed, so the assembled archive is neither a release nor a reproducible build
   assembled:    $host_archive (sha256 $(sha256_of "$host_archive"))
   expected:     commit $expected_commit${BUILD_DIR:+ (HEAD of $BUILD_DIR)}; Cargo.lock sha256 ${lock_sha:-UNRESOLVED}"
 fi

--- a/scripts/release-proof/bin/kin-release-preflight.d/proof-flow.sh
+++ b/scripts/release-proof/bin/kin-release-preflight.d/proof-flow.sh
@@ -17,8 +17,8 @@
 # Contract (environment):
 #   PF_ROOT             leg root (created); HOME, KIN_HOME, temp, probe live under it
 #   PF_ARCHIVE          the release-shaped kin-<os>-<arch>.tar.gz to install
-#   PF_TOOLS            dir holding install.sh, validate.mjs and, when present,
-#                       check-glibc-floor.mjs and kin-magic-repro
+#   PF_TOOLS            dir holding install.sh, validate.mjs and kin-magic-repro;
+#                       check-glibc-floor.mjs is used only for legacy VFS archives
 #   PF_LEG              leg name for the result
 #   PF_RUNNER_OS        macOS | Linux         PF_RUNNER_ARCH  ARM64 | X64
 #   PF_SETUP_SHELL      zsh | bash            (what kin setup is told)
@@ -31,7 +31,8 @@
 #   PF_PYTHON           exact tomllib-capable Python executable (default python3)
 #   PF_SETTLE_SECONDS   settle budget (default 180, the workflow's)
 #   PF_QUIESCE_SECONDS  kin status --wait-quiesce (default 60, the workflow's)
-#   PF_GLIBC_FLOOR      1 runs check-glibc-floor.mjs on kin-vfs and the shim
+#   PF_GLIBC_FLOOR      1 runs check-glibc-floor.mjs only when a legacy archive
+#                       carries the retired kin-vfs and preload shim pair
 #   PF_MAGIC_REPRO      1 runs kin-magic-repro against the installed binaries
 #   PF_EMULATED         1 marks a leg running under CPU emulation: the daemon-
 #                       runtime probe steps are skipped because they are
@@ -275,6 +276,7 @@ trap 'say "interrupted"; FINAL_RC=130; exit 130' INT TERM
 ARCHIVE_NAME="$(basename "$PF_ARCHIVE")"
 ARCHIVE_SHA=""
 CONTENT_ROOT=""
+LEGACY_VFS=0
 ARTIFACT_NAME="${ARCHIVE_NAME%.tar.gz}"
 case "$PF_RUNNER_OS" in
   Linux) SHIM_NAME="libkin_vfs_shim.so" ;;
@@ -308,6 +310,20 @@ step_stage_archive() {
   for required in kin kin-daemon; do
     [ -f "$CONTENT_ROOT/$required" ] || { echo "$required missing from $ARCHIVE_NAME" >&2; exit 1; }
   done
+  has_vfs=0
+  has_shim=0
+  [ -f "$CONTENT_ROOT/kin-vfs" ] && has_vfs=1
+  [ -n "$SHIM_NAME" ] && [ -f "$CONTENT_ROOT/$SHIM_NAME" ] && has_shim=1
+  if [ "$has_vfs" != "$has_shim" ]; then
+    echo "archive carries a partial retired VFS runtime pair" >&2
+    exit 1
+  fi
+  if [ "$has_vfs" = 1 ]; then
+    LEGACY_VFS=1
+    echo "legacy VFS runtime pair: present"
+  else
+    echo "retired VFS runtime pair: absent"
+  fi
   ls -la "$CONTENT_ROOT"
   # The archive under test must be the one this host can run: a Linux archive
   # reaches this script only inside a Linux container.
@@ -344,8 +360,8 @@ step_stage_archive() {
   printf '%s  %s\n' "$ARCHIVE_SHA" "$ARCHIVE_NAME" > "$stub/$ARCHIVE_NAME.sha256"
   echo "install mirror: $PF_ROOT/stub (version $INSTALL_VERSION)"
   {
-    printf 'archive=%s\narchive_sha256=%s\ncontent_root=%s\nkin_version_line=%s\ndaemon_version_line=%s\nstamp_sha=%s\ninstall_version=%s\n' \
-      "$PF_ARCHIVE" "$ARCHIVE_SHA" "$CONTENT_ROOT" "$KIN_VERSION_LINE" "$DAEMON_VERSION_LINE" "$STAMP_SHA" "$INSTALL_VERSION"
+    printf 'archive=%s\narchive_sha256=%s\ncontent_root=%s\nlegacy_vfs=%s\nkin_version_line=%s\ndaemon_version_line=%s\nstamp_sha=%s\ninstall_version=%s\n' \
+      "$PF_ARCHIVE" "$ARCHIVE_SHA" "$CONTENT_ROOT" "$LEGACY_VFS" "$KIN_VERSION_LINE" "$DAEMON_VERSION_LINE" "$STAMP_SHA" "$INSTALL_VERSION"
   } > "$PF_ROOT/archive.env"
 }
 run_step stage-archive 1 "$PF_ROOT" step_stage_archive
@@ -353,6 +369,7 @@ if [ -f "$PF_ROOT/archive.env" ]; then
   # Re-read the values the subshell resolved.
   ARCHIVE_SHA="$(sed -n 's/^archive_sha256=//p' "$PF_ROOT/archive.env")"
   CONTENT_ROOT="$(sed -n 's/^content_root=//p' "$PF_ROOT/archive.env")"
+  LEGACY_VFS="$(sed -n 's/^legacy_vfs=//p' "$PF_ROOT/archive.env")"
   KIN_VERSION_LINE="$(sed -n 's/^kin_version_line=//p' "$PF_ROOT/archive.env")"
   DAEMON_VERSION_LINE="$(sed -n 's/^daemon_version_line=//p' "$PF_ROOT/archive.env")"
   STAMP_SHA="$(sed -n 's/^stamp_sha=//p' "$PF_ROOT/archive.env")"
@@ -375,7 +392,7 @@ step_glibc_floor() {
   fi
   node "$PF_TOOLS/check-glibc-floor.mjs" "$CONTENT_ROOT/kin-vfs" "$CONTENT_ROOT/$SHIM_NAME"
 }
-if [ "$PF_GLIBC_FLOOR" = 1 ] && [ "$PF_RUNNER_OS" = Linux ]; then
+if [ "$PF_GLIBC_FLOOR" = 1 ] && [ "$PF_RUNNER_OS" = Linux ] && [ "$LEGACY_VFS" = 1 ]; then
   run_step glibc-floor 0 "$PF_ROOT" step_glibc_floor
 fi
 
@@ -474,7 +491,11 @@ step_vfs_components() {
   for (const component of components) console.log(`${component.name}: ${component.sha256} (${component.installed_path})`);
 NODE
 }
-run_step vfs-components 0 "$WORKSPACE" step_vfs_components
+if [ "$LEGACY_VFS" = 1 ]; then
+  run_step vfs-components 0 "$WORKSPACE" step_vfs_components
+else
+  say "step vfs-components: SKIPPED (retired runtime absent from this archive)"
+fi
 
 # ------------------------------- 5. First-run repository, daemon, and setup proof
 step_first_run() {
@@ -1022,8 +1043,10 @@ C
   cleanup_vfs
   trap - INT TERM
 }
-if [ "$PF_EMULATED" = 1 ]; then
-  say "step vfs-projection: SKIPPED (emulated leg; the projection is served by the kin-vfs daemon through the preload shim, daemon-runtime that binds on real runners)"
+if [ "$LEGACY_VFS" != 1 ]; then
+  say "step vfs-projection: SKIPPED (retired runtime absent from this archive)"
+elif [ "$PF_EMULATED" = 1 ]; then
+  say "step vfs-projection: SKIPPED (emulated legacy runtime leg; daemon behavior binds on real runners)"
 else
   run_step vfs-projection 0 "$PROBE" step_vfs_projection
 fi
@@ -1213,6 +1236,7 @@ step_validate() {
   PF_EXPECTED_COMMIT="$PF_EXPECTED_COMMIT" \
   PF_EXPECTED_LOCK_SHA="$PF_EXPECTED_LOCK_SHA" \
   PF_RUNNER_OS="$RUNNER_OS" \
+  PF_LEGACY_VFS="$LEGACY_VFS" \
   PF_ALLOW_DIRTY="$PF_ALLOW_DIRTY" \
   PF_HOST_APPS="$PF_HOST_APPS" \
   PF_RESULT_JSON="$PF_ROOT/validate.json" \
@@ -1257,7 +1281,7 @@ fi
 # ------------------------------------------------------------------ 12. result
 PF_ROOT="$PF_ROOT" PF_LEG="$PF_LEG" STEPS_TSV="$STEPS_TSV" ARCHIVE_ENV="$PF_ROOT/archive.env" \
 PF_RUNNER_OS="$PF_RUNNER_OS" PF_RUNNER_ARCH="$PF_RUNNER_ARCH" PF_EXPECTED_COMMIT="$PF_EXPECTED_COMMIT" \
-PF_EXPECTED_LOCK_SHA="$PF_EXPECTED_LOCK_SHA" PF_ALLOW_DIRTY="$PF_ALLOW_DIRTY" \
+PF_EXPECTED_LOCK_SHA="$PF_EXPECTED_LOCK_SHA" PF_LEGACY_VFS="$LEGACY_VFS" PF_ALLOW_DIRTY="$PF_ALLOW_DIRTY" \
 node - <<'NODE'
 const fs = require("fs");
 const path = require("path");
@@ -1328,7 +1352,7 @@ const result = {
     stamp_sha: archiveEnv.stamp_sha ?? null,
     version: archiveEnv.install_version ?? null,
   },
-  expected: { commit: process.env.PF_EXPECTED_COMMIT || null, lock_sha256: process.env.PF_EXPECTED_LOCK_SHA || null, allow_dirty: process.env.PF_ALLOW_DIRTY === "1" },
+  expected: { commit: process.env.PF_EXPECTED_COMMIT || null, lock_sha256: process.env.PF_EXPECTED_LOCK_SHA || null, legacy_vfs: process.env.PF_LEGACY_VFS === "1", allow_dirty: process.env.PF_ALLOW_DIRTY === "1" },
   steps,
   glibc_floor: glibc ? { status: glibc.status, detail: glibc.status === "PASS" ? lastLines(readMaybe(glibc.log), 2).join(" | ") : glibc.failing } : null,
   assertions: validate,

--- a/scripts/release-proof/bin/kin-release-preflight.d/validate.mjs
+++ b/scripts/release-proof/bin/kin-release-preflight.d/validate.mjs
@@ -30,20 +30,11 @@
 //   PF_EXPECTED_COMMIT  40-hex commit the binaries must report, or empty
 //   PF_EXPECTED_LOCK_SHA 64-hex sha256 of that commit's Cargo.lock, or empty
 //   PF_RUNNER_OS        macOS | Linux
-//   PF_LOCAL_BUILD      1 declares that the bytes under test carry no kin-vfs,
-//                       the port of the workflow's `local_artifact` mode. The
-//                       workflow sets that input when a pull request installs
-//                       binaries it built itself, which exist for kin and
-//                       kin-daemon only, and the capability contract then
-//                       requires vfs_projection unsupported rather than
-//                       healthy. No preflight leg sets it today: --archive and
-//                       --rc-run judge whole release-layout archives, and
-//                       --build overlays the built kin and kin-daemon onto a
-//                       base release archive that supplies kin-vfs, the shim
-//                       and KinNotifier.app. It is carried so the two
-//                       contracts stay diffable, and so a future mode that
-//                       does drop the VFS bytes has to say so rather than
-//                       silently failing an assertion that was right
+//   PF_LEGACY_VFS       1 only when the archive under test carries the complete
+//                       retired VFS runtime pair. New archives and local
+//                       artifacts omit it and must report vfs_projection as
+//                       unsupported. This keeps an old published archive
+//                       verifiable without permitting the pair in new output.
 //   PF_EMULATED         1 waives assertions whose capture is missing: an
 //                       emulated leg skips the daemon-runtime producer steps,
 //                       so those captures are absent by design (present
@@ -101,7 +92,7 @@ import path from "node:path";
 // by that pull request rather than by a release.
 export const PORTED_FROM = {
   file: ".github/workflows/install-proof.yml",
-  sha256: "a92d64226a0ed4e99b8078cb3469a1b4027503eb0cc9e013b79d4477e8de6f26",
+  sha256: "b9d95da504c2223ff4322bc60c735f1cc0dba4dbb806ae8c65cdc250f20598d4",
 };
 
 class Unreadable extends Error {}
@@ -109,9 +100,7 @@ class Unreadable extends Error {}
 const captures = process.env.PF_CAPTURES || process.cwd();
 const runnerOs = process.env.PF_RUNNER_OS || (process.platform === "darwin" ? "macOS" : "Linux");
 const isWindows = runnerOs === "Windows";
-// The workflow's `isPullRequestBuild`, which it derives from the LOCAL_ARTIFACT
-// input. See PF_LOCAL_BUILD above for why no preflight leg sets this.
-const isLocalBuild = process.env.PF_LOCAL_BUILD === "1";
+const legacyVfs = process.env.PF_LEGACY_VFS === "1";
 const allowDirty = process.env.PF_ALLOW_DIRTY === "1";
 const emulated = process.env.PF_EMULATED === "1";
 const home = process.env.PF_HOME || os.homedir();
@@ -421,7 +410,7 @@ const required = new Map([
   ["shell_path", "healthy"],
   ["setup_ledger", "healthy"],
   ["registry_authority", isWindows ? "unsupported" : "healthy"],
-  ["vfs_projection", isWindows || isLocalBuild ? "unsupported" : "healthy"],
+  ["vfs_projection", isWindows || !legacyVfs ? "unsupported" : "healthy"],
   ["mcp_client_claude", "healthy"],
   ["mcp_client_cursor", "healthy"],
   ["mcp_client_codex", "healthy"],

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -119,20 +119,6 @@ RELEASE_TRAIN_BODY_POLICY = "scripts/release-train-body.mjs"
 RELEASE_TRAIN_BODY_BEGIN = "<!-- kin-release-train:begin -->"
 RELEASE_TRAIN_BODY_END = "<!-- kin-release-train:end -->"
 ASSERTION_REACHABILITY_POLICY = "scripts/test-assertion-reachability.py"
-GLIBC_FLOOR_GUARD = ROOT / "scripts" / "check-glibc-floor.mjs"
-GLIBC_FLOOR_GUARD_POLICY = "scripts/check-glibc-floor.mjs"
-GLIBC_FLOOR_TEST = ROOT / "scripts" / "check-glibc-floor.test.mjs"
-GLIBC_FLOOR_TEST_POLICY = "scripts/check-glibc-floor.test.mjs"
-GLIBC_FLOOR_RELEASE_CHECK = (
-    'run: node scripts/check-glibc-floor.mjs "$ARTIFACT/kin-vfs" "$ARTIFACT/$SHIM_NAME"'
-)
-GLIBC_FLOOR_BUILD_READ = (
-    'floor="$(node "$GITHUB_WORKSPACE/scripts/check-glibc-floor.mjs" --print-floor)"'
-)
-KIN_VFS_COMPAT_GUARD = ROOT / "scripts" / "check-kin-vfs-compat.mjs"
-KIN_VFS_COMPAT_GUARD_POLICY = "scripts/check-kin-vfs-compat.mjs"
-KIN_VFS_COMPAT_TEST = ROOT / "scripts" / "check-kin-vfs-compat.test.mjs"
-KIN_VFS_COMPAT_TEST_POLICY = "scripts/check-kin-vfs-compat.test.mjs"
 INSTALLER_ASSET_GUARD = ROOT / "scripts" / "verify-installer-release-assets.py"
 INSTALLER_ASSET_GUARD_POLICY = "scripts/verify-installer-release-assets.py"
 INSTALLER_ASSET_FALSIFIER = ROOT / "scripts" / "falsify-installer-release-assets.py"
@@ -649,7 +635,6 @@ UBUNTU_SHARD_ONE_ONLY_GATES = (
     "Validate mandatory Homebrew release outcome gate",
     "Validate automatic release policy",
     "Check the RC build mirrors the release build",
-    "Verify Kin/kin-vfs compatibility at the pinned release input",
     "Check formatting",
     "Check Zero File-Search Invariant",
     "Check Zero File-Search Invariant (answer modules)",
@@ -1022,7 +1007,7 @@ EXPECTED_DYNAMIC_JOB_CONTEXT_SHA256 = {
     (
         ".github/workflows/rc-build.yml",
         "build",
-    ): "8dc0699fb69599edbca87492f3f3a895aefa3bea8384c86d8fc11fef99f9d52a",
+    ): "ef55f31e1fbf929910766fe3b1cdfc964aeda3c56a35ec336772b7964e77ae93",
     (
         ".github/workflows/rc-build.yml",
         "capability",
@@ -1034,7 +1019,7 @@ EXPECTED_DYNAMIC_JOB_CONTEXT_SHA256 = {
     (
         ".github/workflows/release.yml",
         "build",
-    ): "ffde401b1343930965ae6a2a89ca3a81b2996af5821b332f65de7eba874e2be2",
+    ): "bfabe8b21b0e8985dd14051ed1c6affa8ec3279477a96507fa2a76507952808c",
     (
         ".github/workflows/release.yml",
         "verify_npm_published",
@@ -2134,7 +2119,7 @@ UNIX_REQUIRED_VALIDATOR_CHECKS = {
     "shell_path": "healthy",
     "setup_ledger": "healthy",
     "registry_authority": "healthy",
-    "vfs_projection": "healthy",
+    "vfs_projection": "unsupported",
     "mcp_client_claude": "healthy",
     "mcp_client_cursor": "healthy",
     "mcp_client_codex": "healthy",
@@ -2189,6 +2174,7 @@ def unix_node_validator_fixture() -> tuple[
         {
             "../expected-commit.txt": VALIDATOR_FIXTURE_COMMIT,
             "../expected-lock-sha.txt": VALIDATOR_FIXTURE_LOCK,
+            "../legacy-vfs-mode.txt": "false",
             "../installed-kin-command.txt": executable,
             "kin-status.json": {
                 "schema": "kin.status.v3",
@@ -2630,6 +2616,21 @@ def assert_unix_node_validator_behavior(step: str) -> None:
     proof, home, environment = unix_node_validator_fixture()
     label = "released-byte Unix install proof"
     assert_node_validator_accepts_fixture(step, label, proof, home, environment)
+
+    # A new archive carries no external VFS pair, so its report must mark the
+    # projection unsupported. Already-published archives that carry the complete
+    # pair still set this mode from their attested inventory and must require the
+    # historical healthy proof. These two fixtures make both arms executable.
+    legacy_proof = copy.deepcopy(proof)
+    legacy_proof["../legacy-vfs-mode.txt"] = "true"
+    for report_path in ("kin-health.json", "kin-doctor.json"):
+        legacy_proof = fixture_with_check_status(
+            legacy_proof, report_path, "vfs_projection", "healthy"
+        )
+        legacy_proof = fixture_with_derived_aggregate(legacy_proof, report_path)
+    assert_node_validator_accepts_fixture(
+        step, f"{label} (legacy VFS archive)", legacy_proof, home, environment
+    )
 
     def reject(
         case: str,
@@ -5792,159 +5793,101 @@ def assert_assertion_reachability_gate_wired(workflow: str) -> None:
         )
 
 
-def assert_kin_vfs_mount_features_built(release: str) -> None:
-    """Keep the shipped kin-vfs able to serve a mounted projection.
+def assert_retired_vfs_runtime_is_absent_from_new_archives(
+    ci: str,
+    release: str,
+    rc_build: str,
+    install_proof: str,
+    archive_shape: str,
+    archive_docs: str,
+    workspace_manifest: str,
+    cli_manifest: str,
+) -> None:
+    """Keep new archives free of the retired external VFS runtime.
 
-    Kin has four projections and only one of them, the injected shim, needs no
-    feature flag. The published `kin-vfs` is built by this workflow from a
-    pinned checkout, and with no `--features` it carries neither `nfs-start` nor
-    `mount`, so every mount reports itself unavailable on every machine that
-    installs Kin. That is invisible from the release side: the archive shape
-    check greps for a file named `kin-vfs` and finds one either way, and nothing
-    else reads what the binary can do.
-
-    macOS builds `nfs` because it carries an NFS client in the base system, and
-    Linux builds `fuse` because it carries libfuse far more widely than a
-    configured NFS client. Both are asserted, because losing either one silently
-    removes a platform's mount without removing anything a reader would notice.
+    `kin-vfs-core` remains a local projection-engine crate used by the CLI. The
+    external `kin-vfs` executable and preload shim are a different, deprecated
+    delivery surface. Future release and RC archives must never build, copy, or
+    attest that external pair, while install proof keeps a conditional reader
+    for already-published archives that carry both files and their provenance.
     """
 
-    release_lines = {line.strip() for line in release.splitlines()}
-    if (
-        'cargo build --locked --release --target "$VFS_TARGET" -p kin-vfs-cli --features nfs'
-        not in release_lines
-    ):
-        raise AssertionError(
-            "release.yml must build the macOS kin-vfs CLI with --features nfs; "
-            "without it the shipped driver carries no nfs-start and every NFS "
-            "mount reports itself unavailable on every install"
-        )
-    if (
-        'cargo zigbuild --locked --release --target "${VFS_TARGET}.${floor}" -p kin-vfs-cli --features fuse'
-        not in release_lines
-    ):
-        raise AssertionError(
-            "release.yml must build the Linux kin-vfs CLI with --features fuse; "
-            "without it the shipped driver carries no mount subcommand and every "
-            "FUSE mount reports itself unavailable on every install"
-        )
+    for workflow, label in ((release, "release.yml"), (rc_build, "rc-build.yml")):
+        for forbidden in (
+            "repository: firelock-ai/kin-vfs",
+            "kin-vfs/target/",
+            "VFS_TARGET",
+            "SHIM_NAME",
+            "vfs_target:",
+            "shim_name:",
+        ):
+            if forbidden in workflow:
+                raise AssertionError(
+                    f"{label} must not build or package retired VFS runtime inputs: {forbidden}"
+                )
+        for policy in (
+            "node scripts/write-release-archive-docs.mjs",
+            "for required in kin kin-daemon README.md INSTALL.md checksums-sha256.txt; do",
+            'require("./scripts/release-archive-shape.cjs")',
+            "classifyReleaseArchiveRoot(artifact, { target })",
+        ):
+            require(workflow, policy, f"{label} new archive contract")
 
-
-def assert_glibc_floor_guard_wired(ci: str, release: str) -> None:
-    """Keep the floor that decides which Linux distributions can start Kin.
-
-    kin and kin-daemon are static musl and carry no glibc floor. The kin-vfs
-    pair is the only glibc-linked thing Kin publishes for Linux, and its floor
-    used to be a property of the runner image rather than of anything under
-    review: Rust std references pidfd_spawnp and pidfd_getpid as weak undefined
-    symbols, the linker binds them to whatever libc the build host exports, and
-    the ubuntu-24.04 images export them at GLIBC_2.39. v0.5.38 shipped a
-    linux-aarch64 kin-vfs that the Debian 12 loader refused outright, while
-    every check in the release stayed green, because nothing read the floor.
-
-    Two halves are required here and neither is sufficient alone. The build
-    must go through the pinned floor, reading it from the guard rather than
-    recording it a second time, or the number the guard enforces and the number
-    the build targets can drift apart. And the release must read the floor back
-    off the packaged bytes, because a pin that quietly stops taking effect
-    looks exactly like a pin that worked.
-    """
-
-    for path, policy in (
-        (GLIBC_FLOOR_GUARD, GLIBC_FLOOR_GUARD_POLICY),
-        (GLIBC_FLOOR_TEST, GLIBC_FLOOR_TEST_POLICY),
-    ):
-        if not path.is_file():
+    for forbidden in ("kin-vfs", "libkin_vfs_shim"):
+        if forbidden in archive_shape:
             raise AssertionError(
-                f"{policy} is missing; the Linux archives could ship a kin-vfs "
-                "no supported distribution can start and nothing would notice"
+                "release archive shape must not allow the retired VFS runtime "
+                f"artifact {forbidden}"
+            )
+    for policy in (
+        'darwin: Object.freeze(["kin", "kin-daemon", ...DOC_FILES]),',
+        'linux: Object.freeze(["kin", "kin-daemon", ...DOC_FILES]),',
+        'windows: Object.freeze(["kin.exe", "kin-daemon.exe", ...DOC_FILES]),',
+    ):
+        require(archive_shape, policy, "release archive root payload")
+
+    for policy in (
+        "const retiredProjectionFiles = [vfs, shim].filter(hasRegularFile);",
+        "release archive carries retired VFS runtime artifact(s):",
+    ):
+        require(archive_docs, policy, "release archive documentation generator")
+
+    for policy in (
+        '"legacy-vfs-mode.txt"',
+        'fail(!names.has("kin-vfs"), "new archive unexpectedly carries kin-vfs");',
+        "manifest.kin_vfs === undefined && platform.kin_vfs === undefined",
+        "const legacyVfsSource = manifest.kin_vfs !== undefined || platform.kin_vfs !== undefined;",
+        'fail(legacyVfs || process.env.RUNNER_OS === "Windows",',
+    ):
+        require(install_proof, policy, "legacy-aware VFS proof boundary")
+    for forbidden in ("expected_vfs_commit:", "REVIEWED_VFS_COMMIT"):
+        if forbidden in install_proof:
+            raise AssertionError(
+                "install proof must derive legacy VFS verification from the archived "
+                f"provenance rather than a current release caller input: {forbidden}"
             )
 
-    # Match whole invocations rather than searching for the path, which a
-    # commented-out line would still satisfy.
-    release_lines = {line.strip() for line in release.splitlines()}
-    if GLIBC_FLOOR_RELEASE_CHECK not in release_lines:
-        raise AssertionError(
-            "release.yml must run "
-            f"{GLIBC_FLOOR_GUARD_POLICY} against the packaged Linux binaries; "
-            "the build's intent to pin a floor is not the same evidence as the "
-            "floor of the bytes about to be published"
-        )
-    if GLIBC_FLOOR_BUILD_READ not in release_lines:
-        raise AssertionError(
-            "release.yml must read the glibc floor from "
-            f"{GLIBC_FLOOR_GUARD_POLICY}; a build targeting one floor while the "
-            "guard enforces another is worse than no guard"
-        )
-    if 'cargo zigbuild --locked --release --target "${VFS_TARGET}.${floor}"' not in release:
-        raise AssertionError(
-            "release.yml must build the Linux kin-vfs binaries against the "
-            "pinned floor; a plain cargo build takes its floor from the runner "
-            "image, which is what shipped an unloadable v0.5.38 kin-vfs"
-        )
-
-    # The tests are load-bearing rather than decorative: the guard's whole
-    # answer is a parse of readelf output, and a parse that silently found
-    # nothing would be a guard that cannot fail.
-    ci_lines = {line.strip() for line in ci.splitlines()}
-    if not ci_lines & {
-        GLIBC_FLOOR_TEST_POLICY,
-        f"{GLIBC_FLOOR_TEST_POLICY} \\",
-        f"./{GLIBC_FLOOR_TEST_POLICY}",
-        f"./{GLIBC_FLOOR_TEST_POLICY} \\",
-    }:
-        raise AssertionError(
-            "ci.yml must run "
-            f"{GLIBC_FLOOR_TEST_POLICY}; the guard reads a floor out of readelf "
-            "output, and an unproven parse is a gate that cannot fail"
-        )
-
-
-def assert_kin_vfs_compat_gate_wired(ci: str) -> None:
-    """Keep the pull-request half of the Kin/kin-vfs compatibility check.
-
-    release.yml refuses a release whose Kin lock resolves a different
-    kin-vfs-core than the pinned kin-vfs checkout builds. That comparison used
-    to run only at release time, so a pull request moving the Kin lock passed
-    every required context and went red after the tag existed, where the tag
-    has already resolved its own workflows and no fix lands without cutting
-    another tag. kin#788 was exactly that shape: its first commit moved the
-    lock to 0.4.2 while the pin still built 0.3.0.
-
-    The gate reads the pin out of release.yml instead of recording it a sixth
-    time, so its unit tests are load-bearing rather than decorative: an
-    extraction that silently found nothing would be a gate that cannot fail.
-    Both halves are required here for that reason.
-    """
-
-    # Match whole invocations rather than searching for the path, which a
-    # commented-out line would still satisfy.
-    lines = {line.strip() for line in ci.splitlines()}
-    command = f"node {KIN_VFS_COMPAT_GUARD_POLICY}"
-    if not lines & {command, f"run: {command}"}:
-        raise AssertionError(
-            "ci.yml must run "
-            f"{KIN_VFS_COMPAT_GUARD_POLICY}; without it a Kin lock change that "
-            "outruns the immutable kin-vfs pin stays green until it reds a tag"
-        )
-    # The test list is a line-continuation block, so the invocation carries a
-    # trailing backslash on every entry but the last.
-    if not lines & {KIN_VFS_COMPAT_TEST_POLICY, f"{KIN_VFS_COMPAT_TEST_POLICY} \\"}:
-        raise AssertionError(
-            "ci.yml must run "
-            f"{KIN_VFS_COMPAT_TEST_POLICY}; the gate reads the pin out of "
-            "release.yml, and an unproven extraction is a gate that cannot fail"
-        )
-    for path, policy in (
-        (KIN_VFS_COMPAT_GUARD, KIN_VFS_COMPAT_GUARD_POLICY),
-        (KIN_VFS_COMPAT_TEST, KIN_VFS_COMPAT_TEST_POLICY),
+    for forbidden in (
+        "scripts/check-kin-vfs-compat.mjs",
+        "scripts/check-kin-vfs-compat.test.mjs",
+        "expected_vfs_commit: """,
     ):
-        if not path.is_file():
+        if forbidden in ci:
             raise AssertionError(
-                f"{policy} is missing; Kin could resolve a kin-vfs-core that "
-                "the pinned release input does not build and no pull request "
-                "would go red"
+                "CI must not retain a current-release compatibility gate for retired "
+                f"external VFS packaging: {forbidden}"
             )
+
+    for policy in (
+        '"crates/kin-vfs-core",',
+        'kin-vfs-core = { path = "crates/kin-vfs-core",',
+    ):
+        require(workspace_manifest, policy, "local kin-vfs-core workspace engine")
+    require(
+        cli_manifest,
+        "kin-vfs-core = { workspace = true }",
+        "CLI projection-engine dependency",
+    )
 
 
 def assert_installer_asset_guard_wired(ci: str, release: str) -> None:
@@ -14171,52 +14114,9 @@ def main() -> None:
     ):
         require(proof_upload, report, "preserved installed-artifact proof report")
 
-    vfs_checkout_count = len(
-        re.findall(r"repository:\s*firelock-ai/kin-vfs\s*$", release, re.MULTILINE)
-    )
-    vfs_checkout_refs = re.findall(
-        r"repository:\s*firelock-ai/kin-vfs\s*$"
-        r"(?:(?!^\s+- name:).)*?^\s+ref:\s*([^\s#]+)",
-        release,
-        re.MULTILINE | re.DOTALL,
-    )
-    if len(vfs_checkout_refs) != vfs_checkout_count or any(
-        re.fullmatch(r"[0-9a-f]{40}", ref) is None for ref in vfs_checkout_refs
-    ):
-        raise AssertionError(
-            "every kin-vfs release checkout must declare a full immutable commit; "
-            f"checkouts={vfs_checkout_count}, refs={vfs_checkout_refs}"
-        )
-    vfs_refs = set(vfs_checkout_refs)
-    vfs_expected = set(re.findall(r"EXPECTED_VFS_COMMIT:\s*([0-9a-f]{40})", release))
-    install_proof_vfs_expected = set(
-        re.findall(r"expected_vfs_commit:\s*([0-9a-f]{40})", release)
-    )
-    if len(vfs_refs) != 1 or vfs_expected != vfs_refs:
-        raise AssertionError(
-            "release workflow must use one immutable kin-vfs commit for build "
-            f"and provenance verification; refs={sorted(vfs_refs)}, "
-            f"expected={sorted(vfs_expected)}"
-        )
-    if install_proof_vfs_expected != vfs_refs:
-        raise AssertionError(
-            "install proof must bind the same immutable kin-vfs commit as the "
-            f"release workflow; release={sorted(vfs_refs)}, "
-            f"install-proof={sorted(install_proof_vfs_expected)}"
-        )
-    # The Kin-side filter moved when kin-vfs-core became a workspace member: a
-    # member carries no `source` line, so a registry-only filter finds zero and the
-    # gate throws in the release build job, after the tag exists. What is pinned here
-    # is the pair of shapes Kin's side must accept, not the old spelling of it, and
-    # the pinned side's strict rule is pinned separately below so loosening it still
-    # has to be a deliberate edit to this list.
-    for policy in (
-        "Verified Kin/kin-vfs release compatibility at kin-vfs-core",
-        'pkg.source === null || pkg.source.startsWith("sparse+")',
-        'pkg.name === "kin-vfs-core" && pkg.source === null',
-        "update the immutable kin-vfs pin",
-    ):
-        require(release, policy, "Kin and pinned kin-vfs release compatibility gate")
+    # New release and RC archive builders no longer have an external VFS source
+    # input. The package and proof boundary is asserted above, while this later
+    # release admission block stays focused on the active shipped runtime.
 
     # What Windows admission does is stated once and asserted from one script.
     # The installer leg proves it on the landing push, which is the commit
@@ -15129,23 +15029,25 @@ def main() -> None:
     build_job = release[build_start:build_end]
     windows_bytes = build_job.index("      - name: Preserve tracked bytes on Windows")
     checkout = build_job.index("      - name: Checkout\n")
-    vfs_checkout = build_job.index("      - name: Checkout kin-vfs")
     lock_assertion = build_job.index(
         "      - name: Verify canonical release input bytes"
     )
     first_compile = build_job.index("      - name: Build kin-cli + kin-daemon (native)")
-    if not windows_bytes < checkout < vfs_checkout < lock_assertion < first_compile:
+    if not windows_bytes < checkout < lock_assertion < first_compile:
         raise AssertionError(
             "release build must disable Windows conversion before checkout and verify "
-            "both tracked lockfiles before compilation"
+            "the tracked Kin lockfile before compilation"
+        )
+    if "kin-vfs" in build_job:
+        raise AssertionError(
+            "release build must not reintroduce retired external VFS build inputs"
         )
     for policy in (
         "if: runner.os == 'Windows'",
         "git config --global core.autocrlf false",
         '["cat-file", "blob", "HEAD:Cargo.lock"]',
-        '[["Kin", process.cwd()], ["kin-vfs", path.join(process.cwd(), "kin-vfs")]]',
         "if (!working.equals(tracked))",
-        "refusing platform-specific release provenance",
+        "refusing release provenance",
     ):
         require(build_job, policy, "cross-platform release lockfile authority")
 
@@ -15598,99 +15500,108 @@ def main() -> None:
                 expected,
                 lambda mutant=mutant: assert_advisory_sweep_authority(mutant, release_train),
             )
-    assert_kin_vfs_compat_gate_wired(ci_workflow)
-    assert_glibc_floor_guard_wired(ci_workflow, release)
-    assert_kin_vfs_mount_features_built(release)
-    expect_assertion(
-        "macOS kin-vfs built without the nfs feature",
-        "--features nfs",
-        lambda: assert_kin_vfs_mount_features_built(
-            release.replace(
-                '-p kin-vfs-cli --features nfs',
-                '-p kin-vfs-cli',
-            )
-        ),
+    rc_build_workflow = workflow_sources[RC_BUILD]
+    archive_shape = (ROOT / "scripts" / "release-archive-shape.cjs").read_text(
+        encoding="utf-8"
     )
-    expect_assertion(
-        "Linux kin-vfs built without the fuse feature",
-        "--features fuse",
-        lambda: assert_kin_vfs_mount_features_built(
-            release.replace(
-                '-p kin-vfs-cli --features fuse',
-                '-p kin-vfs-cli',
-            )
-        ),
+    archive_docs = (ROOT / "scripts" / "write-release-archive-docs.mjs").read_text(
+        encoding="utf-8"
     )
-    expect_assertion(
-        "release.yml stops reading the glibc floor off the packaged binaries",
-        "release.yml must run",
-        lambda: assert_glibc_floor_guard_wired(
-            ci_workflow,
-            release.replace(GLIBC_FLOOR_RELEASE_CHECK, "run: true"),
-        ),
+    workspace_manifest = (ROOT / "Cargo.toml").read_text(encoding="utf-8")
+    cli_manifest = (ROOT / "crates" / "kin-cli" / "Cargo.toml").read_text(
+        encoding="utf-8"
     )
-    expect_assertion(
-        "the floor check survives only as a commented-out release.yml step",
-        "release.yml must run",
-        lambda: assert_glibc_floor_guard_wired(
-            ci_workflow,
-            release.replace(
-                GLIBC_FLOOR_RELEASE_CHECK,
-                GLIBC_FLOOR_RELEASE_CHECK.replace("run: ", "run: # "),
+    assert_retired_vfs_runtime_is_absent_from_new_archives(
+        ci_workflow,
+        release,
+        rc_build_workflow,
+        install_proof,
+        archive_shape,
+        archive_docs,
+        workspace_manifest,
+        cli_manifest,
+    )
+    for label, expected, inputs in (
+        (
+            "release packaging restores an external kin-vfs checkout",
+            "must not build or package retired VFS runtime inputs",
+            {"release": release + "\nrepository: firelock-ai/kin-vfs\n"},
+        ),
+        (
+            "RC packaging restores a VFS target input",
+            "must not build or package retired VFS runtime inputs",
+            {"rc_build": rc_build_workflow + "\nVFS_TARGET=legacy\n"},
+        ),
+        (
+            "a new archive stops rejecting kin-vfs in its attested inventory",
+            "legacy-aware VFS proof boundary",
+            {
+                "install_proof": install_proof.replace(
+                    'fail(!names.has("kin-vfs"), "new archive unexpectedly carries kin-vfs");',
+                    'fail(true, "new archive unexpectedly carries kin-vfs");',
+                    1,
+                )
+            },
+        ),
+        (
+            "legacy source provenance can omit a VFS pair on Unix",
+            "legacy-aware VFS proof boundary",
+            {
+                "install_proof": install_proof.replace(
+                    'fail(legacyVfs || process.env.RUNNER_OS === "Windows",',
+                    'fail(legacyVfs || process.env.RUNNER_OS === "Linux",',
+                    1,
+                )
+            },
+        ),
+        (
+            "the archive shape readmits a VFS executable",
+            "must not allow the retired VFS runtime artifact",
+            {
+                "archive_shape": archive_shape.replace(
+                    'darwin: Object.freeze(["kin", "kin-daemon", ...DOC_FILES]),',
+                    'darwin: Object.freeze(["kin", "kin-daemon", "kin-vfs", ...DOC_FILES]),',
+                    1,
+                )
+            },
+        ),
+        (
+            "the CLI drops its local projection engine",
+            "CLI projection-engine dependency",
+            {
+                "cli_manifest": cli_manifest.replace(
+                    "kin-vfs-core = { workspace = true }",
+                    "# kin-vfs-core removed",
+                    1,
+                )
+            },
+        ),
+    ):
+        values = {
+            "ci": ci_workflow,
+            "release": release,
+            "rc_build": rc_build_workflow,
+            "install_proof": install_proof,
+            "archive_shape": archive_shape,
+            "archive_docs": archive_docs,
+            "workspace_manifest": workspace_manifest,
+            "cli_manifest": cli_manifest,
+        }
+        values.update(inputs)
+        expect_assertion(
+            label,
+            expected,
+            lambda values=values: assert_retired_vfs_runtime_is_absent_from_new_archives(
+                values["ci"],
+                values["release"],
+                values["rc_build"],
+                values["install_proof"],
+                values["archive_shape"],
+                values["archive_docs"],
+                values["workspace_manifest"],
+                values["cli_manifest"],
             ),
-        ),
-    )
-    expect_assertion(
-        "the release build stops reading the floor from the guard that enforces it",
-        "must read the glibc floor",
-        lambda: assert_glibc_floor_guard_wired(
-            ci_workflow,
-            release.replace(GLIBC_FLOOR_BUILD_READ, 'floor="2.31"'),
-        ),
-    )
-    expect_assertion(
-        "the Linux kin-vfs build reverts to taking its floor from the runner image",
-        "must build the Linux kin-vfs binaries against the pinned floor",
-        lambda: assert_glibc_floor_guard_wired(
-            ci_workflow,
-            release.replace(
-                'cargo zigbuild --locked --release --target "${VFS_TARGET}.${floor}"',
-                'cargo build --locked --release --target "$VFS_TARGET"',
-            ),
-        ),
-    )
-    expect_assertion(
-        "ci.yml keeps the floor guard but drops the tests proving its parse",
-        "ci.yml must run",
-        lambda: assert_glibc_floor_guard_wired(
-            ci_workflow.replace(GLIBC_FLOOR_TEST_POLICY, "scripts/absent.test.mjs"),
-            release,
-        ),
-    )
-    expect_assertion(
-        "ci.yml drops the pull-request Kin/kin-vfs compatibility gate",
-        "ci.yml must run",
-        lambda: assert_kin_vfs_compat_gate_wired(
-            ci_workflow.replace(f"run: node {KIN_VFS_COMPAT_GUARD_POLICY}", "run: true")
-        ),
-    )
-    expect_assertion(
-        "the Kin/kin-vfs gate survives only as a commented-out ci.yml step",
-        "ci.yml must run",
-        lambda: assert_kin_vfs_compat_gate_wired(
-            ci_workflow.replace(
-                f"run: node {KIN_VFS_COMPAT_GUARD_POLICY}",
-                f"run: # node {KIN_VFS_COMPAT_GUARD_POLICY}",
-            )
-        ),
-    )
-    expect_assertion(
-        "ci.yml keeps the Kin/kin-vfs gate but drops the tests proving its parse",
-        "ci.yml must run",
-        lambda: assert_kin_vfs_compat_gate_wired(
-            ci_workflow.replace(KIN_VFS_COMPAT_TEST_POLICY, "scripts/absent.test.mjs")
-        ),
-    )
+        )
     assert_installer_asset_guard_wired(ci_workflow, release)
     expect_assertion(
         "ci.yml drops the guard that installer asset names are published",
@@ -18178,7 +18089,6 @@ jobs:
         "always()",
         "needs.publish.result == 'success'",
         "uses: ./.github/workflows/install-proof.yml",
-        "expected_vfs_commit: 199818f0d1d9ff934de76b73b353183352db08b3",
     ):
         require(install_proof_job, policy, "mandatory public install proof")
 

--- a/scripts/write-release-archive-docs.mjs
+++ b/scripts/write-release-archive-docs.mjs
@@ -6,11 +6,9 @@
 // The v0.5.40 archive was four executables and no words. Both arms of the
 // isolated stranger run installed it successfully and both scored the packaging
 // below the binaries, for the same reason: a stranger's first two decisions,
-// where the executables go and what to do with the shared library, are
-// unguided, and no `kin` command can advise them before `kin` is on PATH. One
-// arm extracted to `~/.local/lib` and symlinked into `/usr/local/bin`, the other
-// to `/opt/kin`, and neither could have known the shim is expected at
-// `~/.kin/lib`.
+// where the executables go are unguided, and no `kin` command can advise them
+// before `kin` is on PATH. One arm extracted to `~/.local/lib` and symlinked
+// into `/usr/local/bin`, and the other to `/opt/kin`.
 //
 // Both arms were also told to verify against `checksums-sha256.txt` and found
 // only the per-archive sidecar. That sidecar covers the tarball; this file
@@ -19,8 +17,8 @@
 //
 // The names considered here are the ones `scripts/release-archive-shape.cjs`
 // admits at the archive root and the ones `kin update` skips by name. The
-// artifact bytes decide whether the optional projection pair is documented, so
-// this generator cannot claim that a matrix-skipped component was packaged.
+// artifact bytes decide the runtime inventory, so this generator cannot claim
+// that a retired component was packaged.
 
 import { createHash } from "node:crypto";
 import fs from "node:fs";
@@ -47,7 +45,6 @@ const shim = windows
     : "libkin_vfs_shim.so";
 
 const binDir = windows ? "%USERPROFILE%\\.kin\\bin" : "~/.kin/bin";
-const libDir = windows ? "%USERPROFILE%\\.kin\\lib" : "~/.kin/lib";
 
 function hasRegularFile(name) {
   try {
@@ -67,23 +64,15 @@ for (const required of [cli, daemon]) {
   }
 }
 
-const hasVfs = hasRegularFile(vfs);
-const hasShim = hasRegularFile(shim);
-if (hasVfs !== hasShim) {
+const retiredProjectionFiles = [vfs, shim].filter(hasRegularFile);
+if (retiredProjectionFiles.length !== 0) {
   console.error(
-    `release archive VFS executable and shim must be packaged together: ${vfs}=${hasVfs}, ${shim}=${hasShim}`,
-  );
-  process.exit(1);
-}
-const hasProjection = hasVfs && hasShim;
-if (!windows && !hasProjection) {
-  console.error(
-    `release archive for ${target} is missing its mandatory VFS executable and shim`,
+    `release archive carries retired VFS runtime artifact(s): ${retiredProjectionFiles.join(", ")}`,
   );
   process.exit(1);
 }
 
-const executableNames = [cli, daemon, ...(hasProjection ? [vfs] : [])];
+const executableNames = [cli, daemon];
 const inlineNames = executableNames
   .map((name) => `\`${name}\``)
   .map((name, index, names) => {
@@ -98,40 +87,11 @@ const makeBinDirCommand = windows ? `mkdir "${binDir}"` : `mkdir -p ${binDir}`;
 const copyExecutablesCommand = windows
   ? executableNames.map((name) => `copy ${name} "${binDir}\\${name}"`).join("\n    ")
   : `cp ${copyNames} ${binDir}/`;
-const makeLibDirCommand = windows ? `mkdir "${libDir}"` : `mkdir -p ${libDir}`;
-const copyShimCommand = windows
-  ? `copy ${shim} "${libDir}\\${shim}"`
-  : `cp ${shim} ${libDir}/`;
 
 const runtimeFiles = [
   `- \`${cli}\` is the command line interface. Start here.`,
   `- \`${daemon}\` serves one repository's graph.\n  \`${cli}\` starts it for you; you do not run it by hand.`,
 ];
-if (hasProjection) {
-  runtimeFiles.push(
-    `- \`${vfs}\` is the filesystem projection driver, which makes graph-backed\n  files look like ordinary files to any tool. It is optional. The CLI and the\n  daemon are fully functional without it.`,
-    `- \`${shim}\` is the library \`${vfs}\` injects. It belongs in\n  \`${libDir}\`, not beside the binaries. See INSTALL.md.`,
-  );
-}
-
-const projectionBoundary = hasProjection
-  ? ""
-  : `\nTransparent filesystem projection is not shipped on native Windows. Use WSL2\nfor the full Kin experience, including projection.`;
-
-const projectionInstall = hasProjection
-  ? `## 2. The shared library
-
-\`${shim}\` is not a program and does not go on PATH. It is injected into other
-processes by the projection driver, and Kin looks for it at one place:
-
-    ${makeLibDirCommand}
-    ${copyShimCommand}
-
-If you skip this, everything except filesystem projection still works, and
-\`kin doctor\` will tell you the shim is missing and offer to copy it from this
-archive for you.`
-  : `Transparent filesystem projection is not shipped on native Windows. Use WSL2
-for the full Kin experience, including projection.`;
 
 const readme = `# Kin ${version} (${target})
 
@@ -141,7 +101,8 @@ about a repository from a graph rather than from raw file search.
 This archive carries these runtime files:
 
 ${runtimeFiles.join("\n")}
-${projectionBoundary}
+
+Deprecated VFS executables and preload shims are not included in release archives.
 
 ## After installing
 
@@ -193,8 +154,6 @@ these files land together:
     ${copyExecutablesCommand}
 
 Then add that directory to PATH.
-
-${projectionInstall}
 
 ## Then
 

--- a/scripts/write-release-archive-docs.test.mjs
+++ b/scripts/write-release-archive-docs.test.mjs
@@ -23,10 +23,8 @@ const TARGETS = [
 ];
 
 const PAYLOAD = {
-  'aarch64-apple-darwin': ['kin', 'kin-daemon', 'kin-vfs', 'libkin_vfs_shim.dylib'],
-  'x86_64-unknown-linux-gnu': ['kin', 'kin-daemon', 'kin-vfs', 'libkin_vfs_shim.so'],
-  // release.yml sets skip_vfs on this row. Its two VFS copies are optional and
-  // therefore produce no archive members when the build step is skipped.
+  'aarch64-apple-darwin': ['kin', 'kin-daemon'],
+  'x86_64-unknown-linux-gnu': ['kin', 'kin-daemon'],
   'x86_64-pc-windows-msvc': ['kin.exe', 'kin-daemon.exe'],
 };
 
@@ -44,7 +42,7 @@ function generate(target, payload = PAYLOAD[target]) {
   };
 }
 
-test('archive docs name only the runtime files that were actually packaged', () => {
+test('archive docs name only the supported runtime files that were actually packaged', () => {
   for (const target of TARGETS) {
     const { readme } = generate(target);
     const listed = [...readme.matchAll(/^- `([^`]+)` /gmu)].map((match) => match[1]);
@@ -59,27 +57,7 @@ test('archive docs name only the runtime files that were actually packaged', () 
   for (const docs of [windows.readme, windows.install]) {
     assert.match(docs, /kin\.exe/, 'Windows docs omit the packaged CLI');
     assert.match(docs, /kin-daemon\.exe/, 'Windows docs omit the packaged daemon');
-    assert.doesNotMatch(
-      docs,
-      /kin-vfs\.exe/,
-      'Windows docs tell the reader to install a VFS executable the archive does not carry',
-    );
-    assert.doesNotMatch(
-      docs,
-      /kin_vfs_shim\.dll/,
-      'Windows docs tell the reader to install a VFS shim the archive does not carry',
-    );
   }
-  assert.match(
-    `${windows.readme}\n${windows.install}`,
-    /Transparent filesystem projection is not shipped on native Windows/,
-    'Windows docs hide the native projection boundary',
-  );
-  assert.match(
-    `${windows.readme}\n${windows.install}`,
-    /WSL2.+full Kin experience/s,
-    'Windows docs do not name the supported full-product path',
-  );
   assert.ok(
     windows.install.includes('mkdir "%USERPROFILE%\\.kin\\bin"'),
     'Windows INSTALL does not quote the managed bin directory',
@@ -128,81 +106,30 @@ test('archive docs name only the runtime files that were actually packaged', () 
       `${target}: Unix docs inherited the Windows support boundary`,
     );
     assert.ok(
-      install.includes(`cp ${PAYLOAD[target].slice(0, 3).join(' ')} ~/.kin/bin/`),
+      install.includes(`cp ${PAYLOAD[target].join(' ')} ~/.kin/bin/`),
       `${target}: INSTALL no longer copies every packaged executable`,
     );
-    assert.ok(
-      install.includes(`cp ${PAYLOAD[target][3]} ~/.kin/lib/`),
-      `${target}: INSTALL no longer copies the packaged VFS shim`,
-    );
   }
 });
 
-test('archive docs refuse a half-packaged VFS pair', () => {
-  const target = 'x86_64-pc-windows-msvc';
-  for (const loneProjectionMember of ['kin-vfs.exe', 'kin_vfs_shim.dll']) {
+test('archive docs refuse every retired VFS artifact', () => {
+  for (const [target, retired] of [
+    ['aarch64-apple-darwin', 'kin-vfs'],
+    ['aarch64-apple-darwin', 'libkin_vfs_shim.dylib'],
+    ['x86_64-unknown-linux-gnu', 'kin-vfs'],
+    ['x86_64-unknown-linux-gnu', 'libkin_vfs_shim.so'],
+    ['x86_64-pc-windows-msvc', 'kin-vfs.exe'],
+    ['x86_64-pc-windows-msvc', 'kin_vfs_shim.dll'],
+  ]) {
     assert.throws(
-      () => generate(target, [...PAYLOAD[target], loneProjectionMember]),
+      () => generate(target, [...PAYLOAD[target], retired]),
       (error) => {
-        assert.match(error.stderr.toString(), /VFS executable and shim must be packaged together/);
+        assert.match(error.stderr.toString(), /carries retired VFS runtime artifact/);
         return true;
       },
-      `generator accepted an unusable archive carrying only ${loneProjectionMember}`,
+      `generator accepted retired ${retired} for ${target}`,
     );
   }
-});
-
-test('archive docs follow a complete Windows VFS pair if the artifact starts shipping it', () => {
-  const payload = [
-    ...PAYLOAD['x86_64-pc-windows-msvc'],
-    'kin-vfs.exe',
-    'kin_vfs_shim.dll',
-  ];
-  const { readme, install } = generate('x86_64-pc-windows-msvc', payload);
-  const listed = [...readme.matchAll(/^- `([^`]+)` /gmu)].map((match) => match[1]);
-  assert.deepEqual(listed, payload, 'Windows README does not follow the packaged VFS pair');
-  for (const executable of payload.slice(0, 3)) {
-    assert.ok(
-      install.includes(`copy ${executable} "%USERPROFILE%\\.kin\\bin\\${executable}"`),
-      `Windows INSTALL does not copy packaged executable ${executable} to a quoted path`,
-    );
-  }
-  assert.ok(
-    install.includes('mkdir "%USERPROFILE%\\.kin\\lib"'),
-    'Windows INSTALL does not quote the managed lib directory',
-  );
-  assert.ok(
-    install.includes(
-      'copy kin_vfs_shim.dll "%USERPROFILE%\\.kin\\lib\\kin_vfs_shim.dll"',
-    ),
-    'Windows INSTALL does not copy the packaged VFS shim to a quoted path',
-  );
-  assert.doesNotMatch(
-    install,
-    /^\s+mkdir %USERPROFILE%/mu,
-    'Windows full-pair INSTALL leaves a managed directory unquoted',
-  );
-  assert.doesNotMatch(
-    install,
-    /^\s+copy [^\r\n]+ %USERPROFILE%/mu,
-    'Windows full-pair INSTALL leaves a copy destination unquoted',
-  );
-  assert.doesNotMatch(
-    `${readme}\n${install}`,
-    /not shipped on native Windows/,
-    'Windows docs claim projection is absent even though the artifact carries the full pair',
-  );
-});
-
-test('archive docs refuse a Unix artifact missing both mandatory VFS members', () => {
-  assert.throws(
-    () => generate('x86_64-unknown-linux-gnu', ['kin', 'kin-daemon']),
-    (error) => {
-      assert.match(error.stderr.toString(), /missing its mandatory VFS executable and shim/);
-      return true;
-    },
-    'generator silently documented a Unix archive without its mandatory VFS pair',
-  );
 });
 
 // An isolated stranger run lost a task to this number. Its container had 12 GiB,


### PR DESCRIPTION
A native agent connected to a search-only MCP profile could change local files without publishing them to repository authority and still report success. Refuse edit and create before changing the projection unless the session and complete transaction lifecycle are available, and return the existing unpublished-change failure when publication is unavailable.

Also remove the retired transparent VFS payload from release archives and update archive validation, install proofs and generated archive documentation. The projection engine and supported session execution remain available.

Validation completed in a clean, isolated public checkout: metadata hygiene, full-history secret scanning, locked Cargo metadata, the public workspace build, and tests and lint for both npm packages. All eight checks returned exit 0. The candidate reproduces the reviewed source tree exactly and preserves source attribution. Normal public CI and acceptance remain required.
